### PR TITLE
fix oauth2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 **node-red-contrib-alexa-remote2-applestrudel**
+- **5.0.56**
+  - fix: Refactoring alexa-remote-ext to use OAuth Login
 - **5.0.55**
   - fix: Get Lists and Remove List Item https://github.com/bbindreiter/node-red-contrib-alexa-remote2-applestrudel/pull/235
 - **5.0.54**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-red-contrib-alexa-remote2-applestrudel
 
-[![npm](https://img.shields.io/npm/v/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel) [![downloads](http[s://img.shields.io/npm/dt/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)
+[![npm](https://img.shields.io/npm/v/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)  [![downloads](http[s://img.shields.io/npm/dt/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)
 
 
 > Forked from [bbindreiter/node-red-contrib-alexa-remote2-applestrudel](https://github.com/bbindreiter/node-red-contrib-alexa-remote2-applestrudel) via [cakebake/node-red-contrib-alexa-remote-cakebaked](https://github.com/cakebake/node-red-contrib-alexa-remote-cakebaked) which was forked from [586837r/node-red-contrib-alexa-remote2](https://github.com/586837r/node-red-contrib-alexa-remote2) to implement OAuth authorisation and keep dependencies up to date.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # node-red-contrib-alexa-remote2-applestrudel
 
-[![npm](https://img.shields.io/npm/v/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel) [![downloads](https://img.shields.io/npm/dt/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)
+[![npm](https://img.shields.io/npm/v/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel) [![downloads](http[s://img.shields.io/npm/dt/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)
 
 
-> Forked from [cakebake/node-red-contrib-alexa-remote-cakebaked](https://github.com/cakebake/node-red-contrib-alexa-remote-cakebaked) which was forked from [586837r/node-red-contrib-alexa-remote2](https://github.com/586837r/node-red-contrib-alexa-remote2) to keep dependencies up to date.
+> Forked from [bbindreiter/node-red-contrib-alexa-remote2-applestrudel](https://github.com/bbindreiter/node-red-contrib-alexa-remote2-applestrudel) via [cakebake/node-red-contrib-alexa-remote-cakebaked](https://github.com/cakebake/node-red-contrib-alexa-remote-cakebaked) which was forked from [586837r/node-red-contrib-alexa-remote2](https://github.com/586837r/node-red-contrib-alexa-remote2) to implement OAuth authorisation and keep dependencies up to date.
 
 This is a collection of Node-RED nodes for interacting with the Alexa API.
 You can emulate routine behaviour, control and query your devices and much more!

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # node-red-contrib-alexa-remote2-applestrudel
 
-[![npm](https://img.shields.io/npm/v/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)  [![downloads](http[s://img.shields.io/npm/dt/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)
+[![npm](https://img.shields.io/npm/v/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel) [![downloads](https://img.shields.io/npm/dt/node-red-contrib-alexa-remote2-applestrudel.svg)](https://www.npmjs.com/package/node-red-contrib-alexa-remote2-applestrudel)
 
 
-> Forked from [bbindreiter/node-red-contrib-alexa-remote2-applestrudel](https://github.com/bbindreiter/node-red-contrib-alexa-remote2-applestrudel) via [cakebake/node-red-contrib-alexa-remote-cakebaked](https://github.com/cakebake/node-red-contrib-alexa-remote-cakebaked) which was forked from [586837r/node-red-contrib-alexa-remote2](https://github.com/586837r/node-red-contrib-alexa-remote2) to implement OAuth authorisation and keep dependencies up to date.
+> Forked from [cakebake/node-red-contrib-alexa-remote-cakebaked](https://github.com/cakebake/node-red-contrib-alexa-remote-cakebaked) which was forked from [586837r/node-red-contrib-alexa-remote2](https://github.com/586837r/node-red-contrib-alexa-remote2) to keep dependencies up to date.
 
 This is a collection of Node-RED nodes for interacting with the Alexa API.
 You can emulate routine behaviour, control and query your devices and much more!

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -29,131 +29,31 @@ function promisify(fun) {
 		});
 	});
 }
-// new 2.2026 wo?
+// new 2.2026 für SendCommand
 /*
 if (err && (err.statusCode === 401 || err.statusCode === 403)) {
     this.log.warn('Alexa session expired, refreshing cookies');
     await this.refreshAlexaCookies();
-}
-*/
+} */
 
-function stringForCompare(str) {
-	return String(str).replace(/[^a-z0-9]/ig, '').toLowerCase();
-}
+class AlexaRemoteExt extends AlexaRemote {
+    constructor(options) {
+        super(options);
+        this.context = options.context;
 
-function ensureMatch(response, template) {
-	if (!tools.matches(response, template)) throw new Error(`unexpected response: "${JSON.stringify(response)}"`);
-}
-
-function isHexColor(str) {
-	if (str.startsWith('#')) str = str.slice(1);
-	if (str.length !== 6) return false;
-	for (const c of str) if (Number.isNaN(parseInt(c, 16))) return false;
-	return true;
-}
-
-/* class AlexaRemoteExt extends AlexaRemote {
-	constructor() {
-		super(...arguments);
-
-		// blacklist: ^(?:\t|[ ]{4})(?![A-z]*constructor)[A-z]*\((?![^\)]*callback)[^\)]*\)
-		const names = [
-			// smarthome
-			'getSmarthomeDevices',
-			'getSmarthomeEntities',
-			'getSmarthomeGroups',
-			'getSmarthomeBehaviourActionDefinitions',
-			'discoverSmarthomeDevice',
-			'deleteAllSmarthomeDevices',
-			// echo
-			'getDevices',
-			'getMedia',
-			'getPlayerInfo',
-			'getDeviceNotificationState',
-			'getDevicePreferences',
-			'getDeviceStatusList',
-			'getNotifications',
-			'getBluetooth',
-			'getWakeWords',
-			'renameDevice',
-			'deleteDevice',
-			'setTunein',
-			'setDoNotDisturb',
-			'setAlarmVolume',
-			'getDoNotDisturb',
-			'sendCommand',
-			// other
-			'getAccount',
-			'getContacts',
-			'getConversations',
-			'getAutomationRoutines',
-			'getMusicProviders',
-			'getActivities',
-			'getCustomerHistoryRecords',
-			'getHomeGroup',
-			'getCards',
-			'sendTextMessage',
-			'deleteConversation',
-
-			// 'connectBluetooth',
-			// 'unpaireBluetooth',
-			// 'disconnectBluetooth',
-
-			'getListsV2',
-			'getList',
-			'getListItems',
-			'addListItem',
-			'updateListItem',
-			'deleteListItem'
-		];
-
-		for (const name of names) {
-			this[name + 'Promise'] = promisify(this[name]);
-		}
-
-		this.errorMessagesExt = {};
-		this.smarthomeSimplifiedByEntityIdExt = new Map();
-		this.smarthomeRequestsRateLimit = new Map();
-		this.routineByIdExt = new Map();
-		this.routineByUtteranceExt = new Map();
-		this.musicProvidersExt = [];
-		this.deviceByIdExt = new Map();
-		this.deviceByNameExt = new Map();
-		this.bluetoothStateByIdExt = new Map();
-		this.wakeWordByIdExt = new Map();
-		this.notificationByIdExt = new Map();
-		this.notificationByNameExt = new Map();
-		this.notificationUpdatesExt = [];
-		this.notificationUpdatesRunning = false;
-
-		this.colorNamesExt = new Set();
-		this.colorNameToLabelExt = new Map();
-		this.compareToColorNameExt = new Map();
-		this.colorNameToHexExt = new Map();
-
-		this.colorTemperatureNamesExt = new Set();
-		this.colorTemperatureNameToLabelExt = new Map();
-		this.compareToColorTemperatureNameExt = new Map();
-		this.colorTemperatureNameToKelvinExt = new Map();
-
-		this.logWarn = () => { };
-	} */
-function AlexaRemoteExt(options) {
-     this.options = options;
-//    this.loggedIn = false;
-
-     this.context = options.context; // Node-RED global
-     this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
+ //    	this.options = options;
+ //    	this.loggedIn = false;
+ //    	this.context = options.context; // Node-RED global
+     	this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
  
-     const { AlexaAuthController } = require('./auth/auth-controller');
-     const { TokenStore } = require('./auth/token-store');
-     const { OAuthDevice } = require('./auth/oauth-device');
+     	const { AlexaAuthController } = require('./auth/auth-controller');
+     	const { TokenStore } = require('./auth/token-store');
+     	const { OAuthDevice } = require('./auth/oauth-device');
  
-     this.tokenStore = new TokenStore(this.context.global);
-     this.oauth = new OAuthDevice(options);
-     this.auth = new AlexaAuthController(this.tokenStore, this.oauth);
- 
-     this.loggedIn = false;
+     	this.tokenStore = new TokenStore(this.context.global);
+     	this.oauth = new OAuthDevice(options);
+     	this.auth = new AlexaAuthController(this.tokenStore, this.oauth);
+     	this.loggedIn = false;
 }
 
 

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -39,11 +39,10 @@ if (err && (err.statusCode === 401 || err.statusCode === 403)) {
 class AlexaRemoteExt extends AlexaRemote {
     constructor(options) {
         super(options);
-        this.context = options.context;
+        this.context = options.context; // Node-RED global
 
  //    	this.options = options;
  //    	this.loggedIn = false;
- //    	this.context = options.context; // Node-RED global
      	this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
  
      	const { AlexaAuthController } = require('./auth/auth-controller');

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -202,7 +202,11 @@ function AlexaRemoteExt(options) {
 				}
 			}
 			else {
-				resolve(this.cookieData);
+				//resolve(this.cookieData); //rem.02.2026
+				resolve({
+        			legacy: true,
+        			note: 'cookieData ignored, OAuth active'
+    			});
 			}
 		}));
 
@@ -654,9 +658,12 @@ function AlexaRemoteExt(options) {
 	}
 
 	async refreshExt() {
-		this._options.cookie = this.cookieData;
-		delete this._options.csrf;
-		return this.initExt(this._options);
+	//	this._options.cookie = this.cookieData;  // 02.2026 obsolet
+	//	delete this._options.csrf;              // 02.2026 obsolet
+	//	return this.initExt(this._options);     // 02.2026 obsolet
+		await this.refreshAlexaCookies();
+	// legacy refresh disabled – OAuth cookie flow active
+	    return true;
 	}
 
 	resetExt() {

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -203,10 +203,11 @@ function AlexaRemoteExt(options) {
 			}
 			else {
 				//resolve(this.cookieData); //rem.02.2026
-				resolve({
+				resolve(null);
+				/*resolve({
         			legacy: true,
         			note: 'cookieData ignored, OAuth active'
-    			});
+    			}); */
 			}
 		}));
 
@@ -661,8 +662,10 @@ function AlexaRemoteExt(options) {
 	//	this._options.cookie = this.cookieData;  // 02.2026 obsolet
 	//	delete this._options.csrf;              // 02.2026 obsolet
 	//	return this.initExt(this._options);     // 02.2026 obsolet
-		await this.refreshAlexaCookies();
 	// legacy refresh disabled – OAuth cookie flow active
+		if (!this.cookie || !this.csrf) {
+	        await this.refreshAlexaCookies();
+	    }
 	    return true;
 	}
 

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -29,6 +29,13 @@ function promisify(fun) {
 		});
 	});
 }
+// new 2.2026 wo?
+/*
+if (err && (err.statusCode === 401 || err.statusCode === 403)) {
+    this.log.warn('Alexa session expired, refreshing cookies');
+    await this.refreshAlexaCookies();
+}
+*/
 
 function stringForCompare(str) {
 	return String(str).replace(/[^a-z0-9]/ig, '').toLowerCase();
@@ -45,7 +52,7 @@ function isHexColor(str) {
 	return true;
 }
 
-class AlexaRemoteExt extends AlexaRemote {
+/* class AlexaRemoteExt extends AlexaRemote {
 	constructor() {
 		super(...arguments);
 
@@ -130,7 +137,25 @@ class AlexaRemoteExt extends AlexaRemote {
 		this.colorTemperatureNameToKelvinExt = new Map();
 
 		this.logWarn = () => { };
-	}
+	} */
+function AlexaRemoteExt(options) {
+     this.options = options;
+//    this.loggedIn = false;
+
+     this.context = options.context; // Node-RED global
+     this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
+ 
+     const { AlexaAuthController } = require('./auth/auth-controller');
+     const { TokenStore } = require('./auth/token-store');
+     const { OAuthDevice } = require('./auth/oauth-device');
+ 
+     this.tokenStore = new TokenStore(this.context.global);
+     this.oauth = new OAuthDevice(options);
+     this.auth = new AlexaAuthController(this.tokenStore, this.oauth);
+ 
+     this.loggedIn = false;
+}
+
 
     _rateLimitRequestHasExpired(date) {
       const expirationDate = Date.now() - REQUEST_RATE_LIMIT_EXPIRATION_IN_M * 60 * 1000;
@@ -196,7 +221,55 @@ class AlexaRemoteExt extends AlexaRemote {
 		
 		return value;
 	}
+    
+	// Begin new 2.2026 override this.checkAuthentication !== super.checkAuthentication
+    checkAuthentication(callback) {
+    	this.auth.ensureAuth()
+        	.then(async () => {
+            	if (!this.cookie || !this.csrf) {
+                	await this.refreshAlexaCookies();
+            	}
+            	callback(true);
+        	})
+        	.catch(err => callback(false, err));
+	}
 
+	// new 2.2026
+	async refreshAlexaCookies() {
+    	const res = await this.auth.request({
+        	method: 'GET',
+        	url: `https://alexa.amazon.${this.options.amazonPage}/spa/index.html`,
+        	headers: {
+            	'User-Agent': this.options.userAgent,
+            	'Accept-Language': this.options.acceptLanguage || 'de-DE'
+        	},
+        	followRedirect: true
+    	});
+
+    	if (!res || !res.headers) {
+        	throw new Error('No response headers from Alexa SPA');
+    	}
+
+    	const setCookie = res.headers['set-cookie'];
+    	if (!setCookie) {
+        	throw new Error('No Alexa cookies received');
+    	}
+
+    	this.cookie = setCookie.map(c => c.split(';')[0]).join('; ');
+    	this.csrf = this._extractCsrf(this.cookie);
+
+    	this.options.headers = this.options.headers || {};
+    	this.options.headers.Cookie = this.cookie;
+    	this.options.headers['csrf'] = this.csrf;
+	}
+
+    // new 2.2026
+	_extractCsrf(cookie) {
+    	const match = cookie.match(/csrf=([^;]+)/);
+    	return match ? match[1] : null;
+	}
+
+	// End // new 2.2026
 	async updateExt() {
 		const handleNonCritical = (promise, prop, label) => promise
 			.then(() => {

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -54,13 +54,6 @@ function promisify(fun) {
 		});
 	});
 }
-// new 2.2026 für SendCommand
-/*
-if (err && (err.statusCode === 401 || err.statusCode === 403)) {
-    this.log.warn('Alexa session expired, refreshing cookies');
-    await this.refreshAlexaCookies();
-} */
-
 function stringForCompare(str) {
 	return String(str).replace(/[^a-z0-9]/ig, '').toLowerCase();
 }
@@ -82,7 +75,7 @@ class AlexaRemoteExt extends AlexaRemote {
 		this.context = options.context; // Node-RED global
 		this.options = options;
 
-		this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
+		this.cookieJar = new tough.CookieJar();
 
 		const { AlexaAuthController } = require('./auth/auth-controller');
 		const { TokenStore } = require('./auth/token-store');
@@ -223,12 +216,7 @@ class AlexaRemoteExt extends AlexaRemote {
 				}
 			}
 			else {
-				//resolve(this.cookieData); //rem.02.2026
 				resolve(null);
-				/*resolve({
-        			legacy: true,
-        			note: 'cookieData ignored, OAuth active'
-    			}); */
 			}
 		}));
 
@@ -248,7 +236,6 @@ class AlexaRemoteExt extends AlexaRemote {
 		return value;
 	}
     
-	// Begin new 2.2026 override this.checkAuthentication !== super.checkAuthentication
     checkAuthentication(callback) {
     	this.auth.ensureAuth()
         	.then(async () => {
@@ -260,7 +247,6 @@ class AlexaRemoteExt extends AlexaRemote {
         	.catch(err => callback(false, err));
 	}
 
-	// new 2.2026
 	async refreshAlexaCookies() {
 		const primaryOptions = this.options || {};
 		const legacyOptions = this._options || {};
@@ -309,13 +295,10 @@ class AlexaRemoteExt extends AlexaRemote {
     	legacyOptions.headers['csrf'] = this.csrf;
 	}
 
-    // new 2.2026
 	_extractCsrf(cookie) {
     	const match = cookie.match(/csrf=([^;]+)/);
     	return match ? match[1] : null;
 	}
-
-	// End // new 2.2026
 	async updateExt() {
 		const handleNonCritical = (promise, prop, label) => promise
 			.then(() => {
@@ -700,10 +683,6 @@ class AlexaRemoteExt extends AlexaRemote {
 	}
 
 	async refreshExt() {
-	//	this._options.cookie = this.cookieData;  // 02.2026 obsolet
-	//	delete this._options.csrf;              // 02.2026 obsolet
-	//	return this.initExt(this._options);     // 02.2026 obsolet
-	// legacy refresh disabled – OAuth cookie flow active
 		if (!this.cookie || !this.csrf) {
 	        await this.refreshAlexaCookies();
 	    }

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -12,11 +12,20 @@ function requireUncached(mod) {
 	return require(mod);
 }
 
+function isAuthError(err) {
+	if (!err) return false;
+	const code = Number(err.statusCode || err.code);
+	if (code === 401 || code === 403) return true;
+	const message = String(err.message || '').toLowerCase();
+	return message.includes('401') || message.includes('403') || message.includes('unauthorized') || message.includes('forbidden');
+}
+
 // my own implementation to keep track of the value on errors, for debugging
 function promisify(fun) {
 	return (function () {
-		return new Promise((resolve, reject) => {
-			fun.bind(this)(...arguments, (err, val) => {
+		const args = Array.from(arguments);
+		const call = () => new Promise((resolve, reject) => {
+			fun.bind(this)(...args, (err, val) => {
 				if (err) {
 					if (typeof err === 'object') {
 						err.value = val;
@@ -27,6 +36,21 @@ function promisify(fun) {
 					resolve(val);
 				}
 			});
+		});
+
+		return call().catch(async error => {
+			if (!isAuthError(error) || typeof this.refreshAlexaCookies !== 'function') {
+				throw error;
+			}
+
+			try {
+				await this.refreshAlexaCookies();
+			}
+			catch (refreshError) {
+				throw refreshError;
+			}
+
+			return call();
 		});
 	});
 }
@@ -238,24 +262,28 @@ class AlexaRemoteExt extends AlexaRemote {
 
 	// new 2.2026
 	async refreshAlexaCookies() {
-		const amazonPage = String(this.options.amazonPage || '')
+		const primaryOptions = this.options || {};
+		const legacyOptions = this._options || {};
+		const normalizeAmazonPage = value => String(value || '')
 			.replace(/^https?:\/\//, '')
 			.replace(/^alexa\./, '')
 			.replace(/\/.*$/, '');
-		const alexaServiceHost = String(this.options.alexaServiceHost || '')
+		const normalizeHost = value => String(value || '')
 			.replace(/^https?:\/\//, '')
 			.replace(/\/.*$/, '');
+		const amazonPage = normalizeAmazonPage(primaryOptions.amazonPage || legacyOptions.amazonPage);
+		const alexaServiceHost = normalizeHost(primaryOptions.alexaServiceHost || legacyOptions.alexaServiceHost || primaryOptions.baseUrl || legacyOptions.baseUrl || this.baseUrl);
 		const spaHost = amazonPage ? `alexa.${amazonPage}` : alexaServiceHost;
 		if (!spaHost) {
-			throw new Error('Missing amazonPage/alexaServiceHost for Alexa SPA URL');
+			throw new Error('Missing amazonPage/alexaServiceHost for Alexa SPA URL (both options and _options are empty)');
 		}
 
 		const res = await this.auth.request({
 			method: 'GET',
 			url: `https://${spaHost}/spa/index.html`,
 			headers: {
-				'User-Agent': this.options.userAgent,
-				'Accept-Language': this.options.acceptLanguage || 'de-DE'
+				'User-Agent': primaryOptions.userAgent || legacyOptions.userAgent,
+				'Accept-Language': primaryOptions.acceptLanguage || legacyOptions.acceptLanguage || 'de-DE'
 			},
 			followRedirect: true
 		});
@@ -272,9 +300,13 @@ class AlexaRemoteExt extends AlexaRemote {
     	this.cookie = setCookie.map(c => c.split(';')[0]).join('; ');
     	this.csrf = this._extractCsrf(this.cookie);
 
-    	this.options.headers = this.options.headers || {};
-    	this.options.headers.Cookie = this.cookie;
-    	this.options.headers['csrf'] = this.csrf;
+    	primaryOptions.headers = primaryOptions.headers || {};
+    	primaryOptions.headers.Cookie = this.cookie;
+    	primaryOptions.headers['csrf'] = this.csrf;
+
+    	legacyOptions.headers = legacyOptions.headers || {};
+    	legacyOptions.headers.Cookie = this.cookie;
+    	legacyOptions.headers['csrf'] = this.csrf;
 	}
 
     // new 2.2026
@@ -705,9 +737,18 @@ class AlexaRemoteExt extends AlexaRemote {
 			noCheck = false;
 		}
 
-		return new Promise((resolve, reject) => {
+		const request = () => new Promise((resolve, reject) => {
 			const callback = (err, val) => err ? reject(err) : resolve(val);
 			this.httpsGet(noCheck, path, callback, flags);
+		});
+
+		return request().catch(async error => {
+			if (!isAuthError(error)) {
+				throw error;
+			}
+
+			await this.refreshAlexaCookies();
+			return request();
 		});
 	}
 

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -1,4 +1,5 @@
 const AlexaRemote = require('alexa-remote2');
+const tough = require('tough-cookie');
 const tools = require('./common.js');
 const known = require('./known-color-values.js');
 const convert = require('./color-convert.js');
@@ -36,35 +37,132 @@ if (err && (err.statusCode === 401 || err.statusCode === 403)) {
     await this.refreshAlexaCookies();
 } */
 
-class AlexaRemoteExt extends AlexaRemote {
-    constructor(options) {
-        super(options);
-        this.context = options.context; // Node-RED global
-
- //    	this.options = options;
- //    	this.loggedIn = false;
-     	this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
- 
-     	const { AlexaAuthController } = require('./auth/auth-controller');
-     	const { TokenStore } = require('./auth/token-store');
-     	const { OAuthDevice } = require('./auth/oauth-device');
- 
-     	this.tokenStore = new TokenStore(this.context.global);
-     	this.oauth = new OAuthDevice(options);
-     	this.auth = new AlexaAuthController(this.tokenStore, this.oauth);
-     	this.loggedIn = false;
+function stringForCompare(str) {
+	return String(str).replace(/[^a-z0-9]/ig, '').toLowerCase();
 }
 
+function ensureMatch(response, template) {
+	if (!tools.matches(response, template)) throw new Error(`unexpected response: "${JSON.stringify(response)}"`);
+}
 
-    _rateLimitRequestHasExpired(date) {
-      const expirationDate = Date.now() - REQUEST_RATE_LIMIT_EXPIRATION_IN_M * 60 * 1000;
+function isHexColor(str) {
+	if (str.startsWith('#')) str = str.slice(1);
+	if (str.length !== 6) return false;
+	for (const c of str) if (Number.isNaN(parseInt(c, 16))) return false;
+	return true;
+}
 
-      if (expirationDate > date) {
-        return true;
-      } else {
-        return false;
-      }
-    }
+class AlexaRemoteExt extends AlexaRemote {
+	constructor(options = {}) {
+		super(options);
+		this.context = options.context; // Node-RED global
+		this.options = options;
+
+		this.cookieJar = new tough.CookieJar(); // bleibt, aber nicht mehr login-relevant
+
+		const { AlexaAuthController } = require('./auth/auth-controller');
+		const { TokenStore } = require('./auth/token-store');
+		const { OAuthDevice } = require('./auth/oauth-device');
+
+		this.tokenStore = new TokenStore(this.context.global);
+		this.oauth = new OAuthDevice(options);
+		this.auth = new AlexaAuthController(this.tokenStore, this.oauth);
+		this.loggedIn = false;
+
+		// blacklist: ^(?:\t|[ ]{4})(?![A-z]*constructor)[A-z]*\((?![^\)]*callback)[^\)]*\)
+		const names = [
+			// smarthome
+			'getSmarthomeDevices',
+			'getSmarthomeEntities',
+			'getSmarthomeGroups',
+			'getSmarthomeBehaviourActionDefinitions',
+			'discoverSmarthomeDevice',
+			'deleteAllSmarthomeDevices',
+			// echo
+			'getDevices',
+			'getMedia',
+			'getPlayerInfo',
+			'getDeviceNotificationState',
+			'getDevicePreferences',
+			'getDeviceStatusList',
+			'getNotifications',
+			'getBluetooth',
+			'getWakeWords',
+			'renameDevice',
+			'deleteDevice',
+			'setTunein',
+			'setDoNotDisturb',
+			'setAlarmVolume',
+			'getDoNotDisturb',
+			'sendCommand',
+			// other
+			'getAccount',
+			'getContacts',
+			'getConversations',
+			'getAutomationRoutines',
+			'getMusicProviders',
+			'getActivities',
+			'getCustomerHistoryRecords',
+			'getHomeGroup',
+			'getCards',
+			'sendTextMessage',
+			'deleteConversation',
+
+			// 'connectBluetooth',
+			// 'unpaireBluetooth',
+			// 'disconnectBluetooth',
+
+			'getListsV2',
+			'getList',
+			'getListItems',
+			'addListItem',
+			'updateListItem',
+			'deleteListItem'
+		];
+
+		for (const name of names) {
+			if (typeof this[name] === 'function') {
+				this[name + 'Promise'] = promisify(this[name]);
+			}
+		}
+
+		this.errorMessagesExt = {};
+		this.smarthomeSimplifiedByEntityIdExt = new Map();
+		this.smarthomeRequestsRateLimit = new Map();
+		this.routineByIdExt = new Map();
+		this.routineByUtteranceExt = new Map();
+		this.musicProvidersExt = [];
+		this.deviceByIdExt = new Map();
+		this.deviceByNameExt = new Map();
+		this.bluetoothStateByIdExt = new Map();
+		this.wakeWordByIdExt = new Map();
+		this.notificationByIdExt = new Map();
+		this.notificationByNameExt = new Map();
+		this.notificationUpdatesExt = [];
+		this.notificationUpdatesRunning = false;
+
+		this.colorNamesExt = new Set();
+		this.colorNameToLabelExt = new Map();
+		this.compareToColorNameExt = new Map();
+		this.colorNameToHexExt = new Map();
+
+		this.colorTemperatureNamesExt = new Set();
+		this.colorTemperatureNameToLabelExt = new Map();
+		this.compareToColorTemperatureNameExt = new Map();
+		this.colorTemperatureNameToKelvinExt = new Map();
+
+		this.logWarn = () => { };
+	}
+
+	_rateLimitRequestHasExpired(date) {
+		const expirationDate = Date.now() - REQUEST_RATE_LIMIT_EXPIRATION_IN_M * 60 * 1000;
+
+		if (expirationDate > date) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 
 	_requestRateLimitCheck(key) {
 	    if (this.smarthomeRequestsRateLimit.has(key)) {
@@ -140,15 +238,27 @@ class AlexaRemoteExt extends AlexaRemote {
 
 	// new 2.2026
 	async refreshAlexaCookies() {
-    	const res = await this.auth.request({
-        	method: 'GET',
-        	url: `https://alexa.amazon.${this.options.amazonPage}/spa/index.html`,
-        	headers: {
-            	'User-Agent': this.options.userAgent,
-            	'Accept-Language': this.options.acceptLanguage || 'de-DE'
-        	},
-        	followRedirect: true
-    	});
+		const amazonPage = String(this.options.amazonPage || '')
+			.replace(/^https?:\/\//, '')
+			.replace(/^alexa\./, '')
+			.replace(/\/.*$/, '');
+		const alexaServiceHost = String(this.options.alexaServiceHost || '')
+			.replace(/^https?:\/\//, '')
+			.replace(/\/.*$/, '');
+		const spaHost = amazonPage ? `alexa.${amazonPage}` : alexaServiceHost;
+		if (!spaHost) {
+			throw new Error('Missing amazonPage/alexaServiceHost for Alexa SPA URL');
+		}
+
+		const res = await this.auth.request({
+			method: 'GET',
+			url: `https://${spaHost}/spa/index.html`,
+			headers: {
+				'User-Agent': this.options.userAgent,
+				'Accept-Language': this.options.acceptLanguage || 'de-DE'
+			},
+			followRedirect: true
+		});
 
     	if (!res || !res.headers) {
         	throw new Error('No response headers from Alexa SPA');

--- a/lib/auth/auth-controller.js
+++ b/lib/auth/auth-controller.js
@@ -1,0 +1,38 @@
+'use strict';
+
+class AlexaAuthController {
+	constructor(tokenStore, oauthDevice) {
+		this.tokenStore = tokenStore;
+		this.oauthDevice = oauthDevice;
+	}
+
+	async ensureAuth() {
+		// OAuth2 bootstrap is handled by alexa-remote2 init flow.
+		// We only need to ensure this class is available for runtime wiring.
+		return true;
+	}
+
+	async request(options = {}) {
+		const method = options.method || 'GET';
+		const headers = options.headers || {};
+
+		const response = await fetch(options.url, {
+			method: method,
+			headers: headers,
+			redirect: options.followRedirect ? 'follow' : 'manual',
+		});
+
+		const setCookie = typeof response.headers.getSetCookie === 'function'
+			? response.headers.getSetCookie()
+			: [];
+
+		return {
+			statusCode: response.status,
+			headers: {
+				'set-cookie': setCookie,
+			},
+		};
+	}
+}
+
+module.exports = { AlexaAuthController };

--- a/lib/auth/oauth-device.js
+++ b/lib/auth/oauth-device.js
@@ -1,0 +1,9 @@
+'use strict';
+
+class OAuthDevice {
+	constructor(options = {}) {
+		this.options = options;
+	}
+}
+
+module.exports = { OAuthDevice };

--- a/lib/auth/token-store.js
+++ b/lib/auth/token-store.js
@@ -1,0 +1,24 @@
+'use strict';
+
+class TokenStore {
+	constructor(globalContext) {
+		this.globalContext = globalContext;
+		this.key = 'alexaRemoteOAuth2';
+	}
+
+	get() {
+		if (!this.globalContext || typeof this.globalContext.get !== 'function') {
+			return null;
+		}
+		return this.globalContext.get(this.key) || null;
+	}
+
+	set(tokens) {
+		if (!this.globalContext || typeof this.globalContext.set !== 'function') {
+			return;
+		}
+		this.globalContext.set(this.key, tokens);
+	}
+}
+
+module.exports = { TokenStore };

--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -314,7 +314,7 @@ module.exports = function (RED) {
 		this.refreshInterval = Number(this.refreshInterval) * 1000 * 60 * 60 * 24;
 		if(this.refreshInterval < 15000) this.refreshInterval = NaN;
 
-		this.alexa = new AlexaRemote().setMaxListeners(32);
+		this.alexa = new AlexaRemote({ context: this.context() }).setMaxListeners(32);
 		this.emitter = new EventEmitter().setMaxListeners(128);
 		this.initing = false;
 		this.state = { code: 'UNINITIALISED', message: '' };
@@ -392,7 +392,7 @@ module.exports = function (RED) {
 			if (!this.alexa) return;
 			this.alexa.resetExt();
 			this.initialised = false;
-			this.alexa = new AlexaRemote();
+			this.alexa = new AlexaRemote({ context: this.context() });
 
       this.ui.smarthome      = JSON.stringify({ entityById: {}, colorNames: [], colorTemperatureNames: []});
       this.ui.devices        = JSON.stringify([]);

--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -484,7 +484,7 @@ module.exports = function (RED) {
 				});
 			}
 
-			const cookieData = await alexa.initExt(config, proxyWaitCallback, this.warnCb).catch(error => {
+			const cookieData = await alexa.initExt(config, proxyWaitCallback, this.warnCb, this.errorCb).catch(error => {
 				if(alexa !== this.alexa) return;
 				this.setState('ERROR', error && error.message);
 				this.initing = false;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
 		"url": "https://github.com/bbindreiter/node-red-contrib-alexa-remote2-applestrudel/issues"
 	},
 	"dependencies": {
-		"alexa-remote2": "^8.0.4"
+		"alexa-remote2": "^8.0.4",
+		"tough-cookie": "^5.1.1"
 	},
 	"engines": {
 		"node": ">=16.0.0"


### PR DESCRIPTION
This built atop manni-2x's excellent work.  I had to revert:

1. some deletions around stringForCompare, ensureMatch, isHexColor since they were still used.
2. put back in the names blacklist and other code in the constructor.

I also:

1. filled in the missing lib/auth classes
2. fixed up the refreshAlexaCookies function to use `amazonPage` and/or `alexaServiceHost`.
3. fixed the call sites for the new constructor parameters
4. added tough-cookie as a dependency

I think there's more opportunity for clean up, but this gets my node-red install going again.