### PR TITLE
persist cookie updates so reboots after a long time don't require re-auth

### DIFF
--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -236,20 +236,38 @@ class AlexaRemoteExt extends AlexaRemote {
 		return value;
 	}
     
-    checkAuthentication(callback) {
-    	this.auth.ensureAuth()
-        	.then(async () => {
-            	if (!this.cookie || !this.csrf) {
-                	await this.refreshAlexaCookies();
-            	}
-            	callback(true);
-        	})
-        	.catch(err => callback(false, err));
+	checkAuthentication(callback) {
+		return super.checkAuthentication(callback);
 	}
 
 	async refreshAlexaCookies() {
 		const primaryOptions = this.options || {};
 		const legacyOptions = this._options || {};
+		const existingCookieData = primaryOptions.cookie || legacyOptions.cookie || this.cookieData;
+
+		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.
+		if (existingCookieData && typeof existingCookieData === 'object' && existingCookieData.loginCookie) {
+			const refreshed = await new Promise((resolve, reject) => {
+				this.refreshCookie((err, result) => err ? reject(err) : resolve(result));
+			});
+
+			const refreshedCookieData = refreshed || this.cookieData || existingCookieData;
+			primaryOptions.cookie = refreshedCookieData;
+			legacyOptions.cookie = refreshedCookieData;
+			this.setCookie(refreshedCookieData);
+
+			if (this.cookie && this.csrf) {
+				primaryOptions.headers = primaryOptions.headers || {};
+				primaryOptions.headers.Cookie = this.cookie;
+				primaryOptions.headers['csrf'] = this.csrf;
+
+				legacyOptions.headers = legacyOptions.headers || {};
+				legacyOptions.headers.Cookie = this.cookie;
+				legacyOptions.headers['csrf'] = this.csrf;
+				return;
+			}
+		}
+
 		const normalizeAmazonPage = value => String(value || '')
 			.replace(/^https?:\/\//, '')
 			.replace(/^alexa\./, '')
@@ -1171,7 +1189,7 @@ class AlexaRemoteExt extends AlexaRemote {
 	async checkAuthenticationExt() {
 		return new Promise((resolve, reject) => {
 			this.checkAuthentication((authenticated, error) =>
-				error ? reject(error) : resolve(authenticated)
+				error ? (isAuthError(error) ? resolve(false) : reject(error)) : resolve(authenticated)
 			);
 		});
 	}

--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -328,6 +328,18 @@ module.exports = function (RED) {
 		this.errorMessages = {};
 		this.ui = {};
 		this.builders = {};
+		this.persistCookieData = () => {
+			if (this.authMethod !== 'proxy' || !this.cookieFile || !this.alexa || !this.alexa.cookieData) return;
+			const json = JSON.stringify(this.alexa.cookieData);
+			try { fs.writeFileSync(this.cookieFile, json, 'utf8'); }
+			catch (error) { this.warnCb(error); }
+		};
+		this.attachAlexaHandlers = () => {
+			if (!this.alexa) return;
+			this.alexa.on('cookie', () => this.persistCookieData());
+		};
+
+		this.attachAlexaHandlers();
 
 		this.buildUiErrorJson = async () => {
 			const a = this.errorMessages;
@@ -392,7 +404,8 @@ module.exports = function (RED) {
 			if (!this.alexa) return;
 			this.alexa.resetExt();
 			this.initialised = false;
-			this.alexa = new AlexaRemote({ context: this.context() });
+			this.alexa = new AlexaRemote({ context: this.context() }).setMaxListeners(32);
+			this.attachAlexaHandlers();
 
       this.ui.smarthome      = JSON.stringify({ entityById: {}, colorNames: [], colorTemperatureNames: []});
       this.ui.devices        = JSON.stringify([]);
@@ -420,7 +433,6 @@ module.exports = function (RED) {
 			config.logger = this.debugCb;
 			config.refreshCookieInterval = 0;
 			config.proxyLogLevel = 'warn';
-			config.cookieJustCreated = true; // otherwise it just tries forever...
 			config.bluetooth = false;
 			config.setupProxy = false;
 			config.apiUserAgentPostfix = pjson.name + '/' + pjson.version;
@@ -434,12 +446,15 @@ module.exports = function (RED) {
 						 || undefined;
 
 					config.cookie = cookieData;
+					config.cookieJustCreated = !cookieData;
 					break;
 				case 'cookie':
 					tools.assign(config, ['cookie'], this.credentials);
+					config.cookieJustCreated = false;
 					break;
 				case 'password':
 					tools.assign(config, ['email', 'password'], this.credentials);
+					config.cookieJustCreated = false;
 					break;
 			}
 
@@ -498,10 +513,7 @@ module.exports = function (RED) {
 			}
 
 			if(this.authMethod === 'proxy' && this.cookieFile) {
-				const data = alexa.cookieData;
-				const json = JSON.stringify(data);
-				try { fs.writeFileSync(this.cookieFile, json, 'utf8'); }
-				catch (error) { this.warnCb(error); }
+				this.persistCookieData();
 			}
 			
 			await this.buildUiJson(false);


### PR DESCRIPTION
I'd been having troubles with the alexa node requiring a reauthentication after a reboot or restart of my node-red instance.

This patch will save the refreshed cookies to the auth file when emitted by alexa-remote2.