### PR TITLE
fix: prevent proxy prompt during cookie auto-refresh

### DIFF
--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -247,24 +247,30 @@ class AlexaRemoteExt extends AlexaRemote {
 
 		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.
 		if (existingCookieData && typeof existingCookieData === 'object' && existingCookieData.loginCookie) {
-			const refreshed = await new Promise((resolve, reject) => {
-				this.refreshCookie((err, result) => err ? reject(err) : resolve(result));
-			});
+			try {
+				const refreshed = await new Promise((resolve, reject) => {
+					if (!this.alexaCookie)
+						this.alexaCookie = requireUncached('alexa-cookie2');
+					this.alexaCookie.refreshAlexaCookie(this._options, (err, result) => err ? reject(err) : resolve(result));
+				});
 
-			const refreshedCookieData = refreshed || this.cookieData || existingCookieData;
-			primaryOptions.cookie = refreshedCookieData;
-			legacyOptions.cookie = refreshedCookieData;
-			this.setCookie(refreshedCookieData);
+				const refreshedCookieData = refreshed || this.cookieData || existingCookieData;
+				primaryOptions.cookie = refreshedCookieData;
+				legacyOptions.cookie = refreshedCookieData;
+				this.setCookie(refreshedCookieData);
 
-			if (this.cookie && this.csrf) {
-				primaryOptions.headers = primaryOptions.headers || {};
-				primaryOptions.headers.Cookie = this.cookie;
-				primaryOptions.headers['csrf'] = this.csrf;
+				if (this.cookie && this.csrf) {
+					primaryOptions.headers = primaryOptions.headers || {};
+					primaryOptions.headers.Cookie = this.cookie;
+					primaryOptions.headers['csrf'] = this.csrf;
 
-				legacyOptions.headers = legacyOptions.headers || {};
-				legacyOptions.headers.Cookie = this.cookie;
-				legacyOptions.headers['csrf'] = this.csrf;
-				return;
+					legacyOptions.headers = legacyOptions.headers || {};
+					legacyOptions.headers.Cookie = this.cookie;
+					legacyOptions.headers['csrf'] = this.csrf;
+					return;
+				}
+			} catch (_e) {
+				// Token refresh failed — fall through to SPA refresh below.
 			}
 		}
 
@@ -757,8 +763,10 @@ class AlexaRemoteExt extends AlexaRemote {
 
 	// overrides
 	refreshCookie(callback) {
-				if (!this.alexaCookie) this.alexaCookie = requireUncached('alexa-cookie2');
-				this.alexaCookie.refreshAlexaCookie(this._options, callback);
+		// delegates to refreshAlexaCookies for SPA fallback
+		this.refreshAlexaCookies()
+			.then(() => callback(null, this.cookieData || this.cookie))
+			.catch(err => callback(err));
 	}
 
 	async sendSequenceNodeExt(sequenceNode) {

--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -447,6 +447,13 @@ module.exports = function (RED) {
 
 					config.cookie = cookieData;
 					config.cookieJustCreated = !cookieData;
+
+					// Prefer the marketplace from saved cookie data (set by
+					// Amazon's getUserData) over the configured value.
+					if (cookieData && cookieData.amazonPage && cookieData.amazonPage !== config.amazonPage) {
+						this.warnCb(`amazonPage corrected: "${config.amazonPage}" → "${cookieData.amazonPage}"`);
+						config.amazonPage = cookieData.amazonPage;
+					}
 					break;
 				case 'cookie':
 					tools.assign(config, ['cookie'], this.credentials);


### PR DESCRIPTION
Two issues caused auto-refresh to fall back to proxy auth ("open browser"):

**1. Domain mismatch.** Saved cookie data contains the correct marketplace (`amazon.ca` from Amazon's `getUserData`) but the account config used `amazon.com`. This caused `/auth/register` to fail with `InvalidToken`. Fix: prefer `amazonPage` from cookie data when it differs from config.

**2. No SPA fallback in the `getCookie` → `refreshCookie` path.** When token refresh fails, `getCookie` calls `generateCookie` → proxy. Fix: `refreshCookie` now delegates to `refreshAlexaCookies`, which falls back to SPA-based cookie refresh (no user interaction). Also wrapped the internal token refresh in try/catch so the SPA fallback is actually reached.

This also mitigates #254 — when `checkAuthentication` times out (likely an Amazon server-side change affecting certain endpoints), the SPA fallback provides fresh session cookies from a different endpoint (`alexa.amazon.xx/spa/index.html`) which may succeed where the normal auth check fails.

The underlying `alexa-cookie2` refresh flow calls `/auth/register` with expired tokens, which is unnecessary during refresh. fkhr79/alexa-cookie@e89c893 addresses this by skipping registration and calling `registerTokenCapabilities` instead.

Tested with 8+ hours / 450+ continuous 60s refresh cycles using an expired (>36h) refresh token — zero proxy prompts.

Co-Authored-By: Claude <noreply@anthropic.com>