### PR TITLE
fix: return cookie data from initExt

### DIFF
--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -233,7 +233,7 @@ class AlexaRemoteExt extends AlexaRemote {
 			this.updateNotificationsExt(payload.eventType, payload.notificationId, String(payload.notificationVersion));
 		});
 		
-		return value;
+		return this.cookieData || value;
 	}
     
 	checkAuthentication(callback) {

--- a/test/init-ext-return.test.js
+++ b/test/init-ext-return.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const Module = require('module');
+
+const expectedCookieData = {
+	loginCookie: 'login-cookie',
+	localCookie: 'local-cookie',
+	csrf: 'csrf-token',
+	refreshToken: 'refresh-token',
+	dataVersion: 2,
+};
+
+class FakeAlexaRemote extends EventEmitter {
+	constructor() {
+		super();
+	}
+}
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+	if (request === 'alexa-remote2') {
+		return FakeAlexaRemote;
+	}
+	if (request === 'tough-cookie') {
+		return { CookieJar: class CookieJar {} };
+	}
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+async function main() {
+	try {
+		const AlexaRemoteExt = require('../lib/alexa-remote-ext');
+
+		const createAlexa = () => new AlexaRemoteExt({
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		});
+
+		const alexa = createAlexa();
+		alexa.init = (config, callback) => {
+			alexa.cookieData = expectedCookieData;
+			callback(null);
+		};
+		alexa.checkAuthenticationExt = async () => true;
+		alexa.updateExt = async () => {};
+
+		const result = await alexa.initExt({});
+
+		assert.strictEqual(result, expectedCookieData);
+
+		const alexaWithoutCookieData = createAlexa();
+		alexaWithoutCookieData.init = (config, callback) => callback(null);
+		alexaWithoutCookieData.checkAuthenticationExt = async () => true;
+		alexaWithoutCookieData.updateExt = async () => {};
+
+		const resultWithoutCookieData = await alexaWithoutCookieData.initExt({});
+
+		assert.strictEqual(resultWithoutCookieData, null);
+	}
+	finally {
+		Module._load = originalLoad;
+	}
+}
+
+main().catch(error => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
### Problem

The Init node sends the resolved value of `account.initAlexa(msg.payload)` as its output.

`account.initAlexa()` returns the value it receives from `alexa.initExt(...)`. During successful initialization, `alexa-remote2` stores the current auth data on `this.cookieData`, but `initExt()` returned the callback value from `this.init(...)`. That value can be `null`, so a successful init can produce no auth payload even though current cookie data exists on the instance.
This breaks the documented Init-node flow where the output payload can be stored and passed back into the Init node later.

### Change

`initExt()` now returns:

```js
this.cookieData || value
```

That returns the actual auth data after successful initialization, while keeping the previous return value as fallback when no `cookieData` exists.
In the Init-node path this does not reuse data from an older Alexa instance: `account.initAlexa()` calls `resetAlexa()` before calling `initExt()`, then keeps the current `this.alexa` instance in a local `alexa` variable and returns the result from that instance.

### Test

Added `test/init-ext-return.test.js` covering both return paths:

- successful init sets `cookieData` and `initExt()` returns that object
- init without `cookieData` keeps the previous fallback return value

Verified with:

```sh
node test/init-ext-return.test.js
node --check <all js files>
git diff --check
```

### Scope

This only fixes the Init-node return value. It does not change proxy login, cookie refresh, or Alexa API request behavior.