### PR TITLE
fix: keep refresh cookie state consistent

### DIFF
--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -284,9 +284,12 @@ class AlexaRemoteExt extends AlexaRemote {
 		const previousRefreshState = {
 			cookie: this.cookie,
 			csrf: this.csrf,
+			macDms: this.macDms,
 			cookieData: this.cookieData,
 			primaryCookie: primaryOptions.cookie,
 			legacyCookie: legacyOptions.cookie,
+			primaryMacDms: primaryOptions.macDms,
+			legacyMacDms: legacyOptions.macDms,
 			primaryFormerRegistrationData: primaryOptions.formerRegistrationData,
 			legacyFormerRegistrationData: legacyOptions.formerRegistrationData,
 			primaryHeadersCookie: primaryOptions.headers && primaryOptions.headers.Cookie,
@@ -297,9 +300,12 @@ class AlexaRemoteExt extends AlexaRemote {
 		const restoreRefreshState = () => {
 			this.cookie = previousRefreshState.cookie;
 			this.csrf = previousRefreshState.csrf;
+			this.macDms = previousRefreshState.macDms;
 			this.cookieData = previousRefreshState.cookieData;
 			primaryOptions.cookie = previousRefreshState.primaryCookie;
 			legacyOptions.cookie = previousRefreshState.legacyCookie;
+			primaryOptions.macDms = previousRefreshState.primaryMacDms;
+			legacyOptions.macDms = previousRefreshState.legacyMacDms;
 			primaryOptions.formerRegistrationData = previousRefreshState.primaryFormerRegistrationData;
 			legacyOptions.formerRegistrationData = previousRefreshState.legacyFormerRegistrationData;
 			if (primaryOptions.headers) {
@@ -344,59 +350,66 @@ class AlexaRemoteExt extends AlexaRemote {
 			}
 		}
 
-		const normalizeAmazonPage = value => String(value || '')
-			.replace(/^https?:\/\//, '')
-			.replace(/^alexa\./, '')
-			.replace(/\/.*$/, '');
-		const normalizeHost = value => String(value || '')
-			.replace(/^https?:\/\//, '')
-			.replace(/\/.*$/, '');
-		const amazonPage = normalizeAmazonPage(primaryOptions.amazonPage || legacyOptions.amazonPage);
-		const alexaServiceHost = normalizeHost(primaryOptions.alexaServiceHost || legacyOptions.alexaServiceHost || primaryOptions.baseUrl || legacyOptions.baseUrl || this.baseUrl);
-		const spaHost = amazonPage ? `alexa.${amazonPage}` : alexaServiceHost;
-		if (!spaHost) {
-			throw new Error('Missing amazonPage/alexaServiceHost for Alexa SPA URL (both options and _options are empty)');
+		let refreshedCookie;
+		let refreshedCsrf;
+		try {
+			const normalizeAmazonPage = value => String(value || '')
+				.replace(/^https?:\/\//, '')
+				.replace(/^alexa\./, '')
+				.replace(/\/.*$/, '');
+			const normalizeHost = value => String(value || '')
+				.replace(/^https?:\/\//, '')
+				.replace(/\/.*$/, '');
+			const amazonPage = normalizeAmazonPage(primaryOptions.amazonPage || legacyOptions.amazonPage);
+			const alexaServiceHost = normalizeHost(primaryOptions.alexaServiceHost || legacyOptions.alexaServiceHost || primaryOptions.baseUrl || legacyOptions.baseUrl || this.baseUrl);
+			const spaHost = amazonPage ? `alexa.${amazonPage}` : alexaServiceHost;
+			if (!spaHost) {
+				throw new Error('Missing amazonPage/alexaServiceHost for Alexa SPA URL (both options and _options are empty)');
+			}
+
+			const existingCookie = this.cookie
+				|| (existingStructuredCookieData && existingStructuredCookieData.localCookie)
+				|| getHeader(primaryOptions.headers, 'Cookie')
+				|| getHeader(legacyOptions.headers, 'Cookie');
+			const spaHeaders = {
+				'Accept-Language': primaryOptions.acceptLanguage || legacyOptions.acceptLanguage || 'de-DE'
+			};
+			const userAgent = primaryOptions.userAgent || legacyOptions.userAgent;
+			if (userAgent) {
+				spaHeaders['User-Agent'] = userAgent;
+			}
+			if (existingCookie) {
+				spaHeaders.Cookie = existingCookie;
+			}
+
+			const res = await this.auth.request({
+				method: 'GET',
+				url: `https://${spaHost}/spa/index.html`,
+				headers: spaHeaders,
+				followRedirect: true
+			});
+
+			if (!res || !res.headers) {
+				throw new Error('No response headers from Alexa SPA');
+			}
+
+			const setCookie = res.headers['set-cookie'];
+			const responseSetCookie = normalizeSetCookieHeaders(setCookie);
+			if (!responseSetCookie.length) {
+				throw new Error('No Alexa cookies received');
+			}
+
+			const responseCookie = responseSetCookie.join('; ');
+			refreshedCsrf = this._extractCsrf(responseCookie);
+			if (!refreshedCsrf) {
+				throw new Error('Alexa SPA cookies did not include csrf');
+			}
+			refreshedCookie = mergeCookieStrings(existingCookie, setCookie);
 		}
-
-		const existingCookie = this.cookie
-			|| (existingStructuredCookieData && existingStructuredCookieData.localCookie)
-			|| getHeader(primaryOptions.headers, 'Cookie')
-			|| getHeader(legacyOptions.headers, 'Cookie');
-		const spaHeaders = {
-			'Accept-Language': primaryOptions.acceptLanguage || legacyOptions.acceptLanguage || 'de-DE'
-		};
-		const userAgent = primaryOptions.userAgent || legacyOptions.userAgent;
-		if (userAgent) {
-			spaHeaders['User-Agent'] = userAgent;
-		}
-		if (existingCookie) {
-			spaHeaders.Cookie = existingCookie;
-		}
-
-		const res = await this.auth.request({
-			method: 'GET',
-			url: `https://${spaHost}/spa/index.html`,
-			headers: spaHeaders,
-			followRedirect: true
-		});
-
-    	if (!res || !res.headers) {
-        	throw new Error('No response headers from Alexa SPA');
-    	}
-
-    	const setCookie = res.headers['set-cookie'];
-		const responseSetCookie = normalizeSetCookieHeaders(setCookie);
-		if (!responseSetCookie.length) {
-        	throw new Error('No Alexa cookies received');
-    	}
-
-		const responseCookie = responseSetCookie.join('; ');
-		const refreshedCsrf = this._extractCsrf(responseCookie);
-		if (!refreshedCsrf) {
+		catch (error) {
 			restoreRefreshState();
-			throw new Error('Alexa SPA cookies did not include csrf');
+			throw error;
 		}
-		const refreshedCookie = mergeCookieStrings(existingCookie, setCookie);
 
 		this.cookie = refreshedCookie;
 		this.csrf = refreshedCsrf;

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -310,6 +310,16 @@ class AlexaRemoteExt extends AlexaRemote {
     	this.cookie = setCookie.map(c => c.split(';')[0]).join('; ');
     	this.csrf = this._extractCsrf(this.cookie);
 
+		if (existingCookieData && typeof existingCookieData === 'object') {
+			const refreshedCookieData = Object.assign({}, existingCookieData, {
+				localCookie: this.cookie,
+				csrf: this.csrf
+			});
+			this.cookieData = refreshedCookieData;
+			primaryOptions.cookie = refreshedCookieData;
+			legacyOptions.cookie = refreshedCookieData;
+		}
+
     	primaryOptions.headers = primaryOptions.headers || {};
     	primaryOptions.headers.Cookie = this.cookie;
     	primaryOptions.headers['csrf'] = this.csrf;

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -244,6 +244,8 @@ class AlexaRemoteExt extends AlexaRemote {
 		const primaryOptions = this.options || {};
 		const legacyOptions = this._options || {};
 		const existingCookieData = primaryOptions.cookie || legacyOptions.cookie || this.cookieData;
+		const existingStructuredCookieData = [primaryOptions.cookie, legacyOptions.cookie, this.cookieData]
+			.find(cookieData => cookieData && typeof cookieData === 'object');
 
 		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.
 		if (existingCookieData && typeof existingCookieData === 'object' && existingCookieData.loginCookie) {
@@ -310,14 +312,21 @@ class AlexaRemoteExt extends AlexaRemote {
     	this.cookie = setCookie.map(c => c.split(';')[0]).join('; ');
     	this.csrf = this._extractCsrf(this.cookie);
 
-		if (existingCookieData && typeof existingCookieData === 'object') {
-			const refreshedCookieData = Object.assign({}, existingCookieData, {
+		if (existingStructuredCookieData) {
+			const refreshedCookieData = Object.assign({}, existingStructuredCookieData, {
 				localCookie: this.cookie,
 				csrf: this.csrf
 			});
 			this.cookieData = refreshedCookieData;
 			primaryOptions.cookie = refreshedCookieData;
 			legacyOptions.cookie = refreshedCookieData;
+			primaryOptions.formerRegistrationData = refreshedCookieData;
+			legacyOptions.formerRegistrationData = refreshedCookieData;
+
+			if (this.csrf) {
+				this.macDms = legacyOptions.macDms = legacyOptions.macDms || refreshedCookieData.macDms;
+				this.emit('cookie', this.cookie, this.csrf, this.macDms);
+			}
 		}
 
     	primaryOptions.headers = primaryOptions.headers || {};

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -243,22 +243,33 @@ class AlexaRemoteExt extends AlexaRemote {
 	async refreshAlexaCookies() {
 		const primaryOptions = this.options || {};
 		const legacyOptions = this._options || {};
-		const existingCookieData = primaryOptions.cookie || legacyOptions.cookie || this.cookieData;
-		const existingStructuredCookieData = [primaryOptions.cookie, legacyOptions.cookie, this.cookieData]
-			.find(cookieData => cookieData && typeof cookieData === 'object');
+		const getTokenRegistrationData = data => tools.isObject(data) && data.loginCookie && data.refreshToken
+			? data
+			: undefined;
+		const tokenRegistrationData = getTokenRegistrationData(primaryOptions.formerRegistrationData)
+			|| getTokenRegistrationData(legacyOptions.formerRegistrationData)
+			|| getTokenRegistrationData(primaryOptions.cookie)
+			|| getTokenRegistrationData(legacyOptions.cookie)
+			|| getTokenRegistrationData(this.cookieData);
+		const existingStructuredCookieData = tokenRegistrationData
+			|| [primaryOptions.cookie, legacyOptions.cookie, this.cookieData]
+				.find(cookieData => tools.isObject(cookieData));
 
 		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.
-		if (existingCookieData && typeof existingCookieData === 'object' && existingCookieData.loginCookie) {
+		if (tokenRegistrationData) {
 			try {
+				legacyOptions.formerRegistrationData = tokenRegistrationData;
 				const refreshed = await new Promise((resolve, reject) => {
 					if (!this.alexaCookie)
 						this.alexaCookie = requireUncached('alexa-cookie2');
-					this.alexaCookie.refreshAlexaCookie(this._options, (err, result) => err ? reject(err) : resolve(result));
+					this.alexaCookie.refreshAlexaCookie(legacyOptions, (err, result) => err ? reject(err) : resolve(result));
 				});
 
-				const refreshedCookieData = refreshed || this.cookieData || existingCookieData;
+				const refreshedCookieData = refreshed || this.cookieData || tokenRegistrationData;
 				primaryOptions.cookie = refreshedCookieData;
 				legacyOptions.cookie = refreshedCookieData;
+				primaryOptions.formerRegistrationData = refreshedCookieData;
+				legacyOptions.formerRegistrationData = refreshedCookieData;
 				this.setCookie(refreshedCookieData);
 
 				if (this.cookie && this.csrf) {

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -281,6 +281,36 @@ class AlexaRemoteExt extends AlexaRemote {
 		const existingStructuredCookieData = tokenRegistrationData
 			|| [primaryOptions.cookie, legacyOptions.cookie, this.cookieData]
 				.find(cookieData => tools.isObject(cookieData));
+		const previousRefreshState = {
+			cookie: this.cookie,
+			csrf: this.csrf,
+			cookieData: this.cookieData,
+			primaryCookie: primaryOptions.cookie,
+			legacyCookie: legacyOptions.cookie,
+			primaryFormerRegistrationData: primaryOptions.formerRegistrationData,
+			legacyFormerRegistrationData: legacyOptions.formerRegistrationData,
+			primaryHeadersCookie: primaryOptions.headers && primaryOptions.headers.Cookie,
+			primaryHeadersCsrf: primaryOptions.headers && primaryOptions.headers['csrf'],
+			legacyHeadersCookie: legacyOptions.headers && legacyOptions.headers.Cookie,
+			legacyHeadersCsrf: legacyOptions.headers && legacyOptions.headers['csrf'],
+		};
+		const restoreRefreshState = () => {
+			this.cookie = previousRefreshState.cookie;
+			this.csrf = previousRefreshState.csrf;
+			this.cookieData = previousRefreshState.cookieData;
+			primaryOptions.cookie = previousRefreshState.primaryCookie;
+			legacyOptions.cookie = previousRefreshState.legacyCookie;
+			primaryOptions.formerRegistrationData = previousRefreshState.primaryFormerRegistrationData;
+			legacyOptions.formerRegistrationData = previousRefreshState.legacyFormerRegistrationData;
+			if (primaryOptions.headers) {
+				primaryOptions.headers.Cookie = previousRefreshState.primaryHeadersCookie;
+				primaryOptions.headers['csrf'] = previousRefreshState.primaryHeadersCsrf;
+			}
+			if (legacyOptions.headers) {
+				legacyOptions.headers.Cookie = previousRefreshState.legacyHeadersCookie;
+				legacyOptions.headers['csrf'] = previousRefreshState.legacyHeadersCsrf;
+			}
+		};
 
 		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.
 		if (tokenRegistrationData) {
@@ -333,9 +363,12 @@ class AlexaRemoteExt extends AlexaRemote {
 			|| getHeader(primaryOptions.headers, 'Cookie')
 			|| getHeader(legacyOptions.headers, 'Cookie');
 		const spaHeaders = {
-			'User-Agent': primaryOptions.userAgent || legacyOptions.userAgent,
 			'Accept-Language': primaryOptions.acceptLanguage || legacyOptions.acceptLanguage || 'de-DE'
 		};
+		const userAgent = primaryOptions.userAgent || legacyOptions.userAgent;
+		if (userAgent) {
+			spaHeaders['User-Agent'] = userAgent;
+		}
 		if (existingCookie) {
 			spaHeaders.Cookie = existingCookie;
 		}
@@ -352,13 +385,15 @@ class AlexaRemoteExt extends AlexaRemote {
     	}
 
     	const setCookie = res.headers['set-cookie'];
-    	if (!setCookie) {
+		const responseSetCookie = normalizeSetCookieHeaders(setCookie);
+		if (!responseSetCookie.length) {
         	throw new Error('No Alexa cookies received');
     	}
 
-		const responseCookie = normalizeSetCookieHeaders(setCookie).join('; ');
+		const responseCookie = responseSetCookie.join('; ');
 		const refreshedCsrf = this._extractCsrf(responseCookie);
 		if (!refreshedCsrf) {
+			restoreRefreshState();
 			throw new Error('Alexa SPA cookies did not include csrf');
 		}
 		const refreshedCookie = mergeCookieStrings(existingCookie, setCookie);

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -20,6 +20,33 @@ function isAuthError(err) {
 	return message.includes('401') || message.includes('403') || message.includes('unauthorized') || message.includes('forbidden');
 }
 
+function getHeader(headers, name) {
+	if (!headers) return undefined;
+	const lowerName = name.toLowerCase();
+	const key = Object.keys(headers).find(candidate => candidate.toLowerCase() === lowerName);
+	return key ? headers[key] : undefined;
+}
+
+function normalizeSetCookieHeaders(setCookie) {
+	if (!setCookie) return [];
+	return (Array.isArray(setCookie) ? setCookie : [setCookie])
+		.map(cookie => String(cookie || '').split(';')[0].trim())
+		.filter(Boolean);
+}
+
+function mergeCookieStrings(existingCookie, setCookie) {
+	const cookieMap = new Map();
+	const addCookie = cookie => {
+		const separator = cookie.indexOf('=');
+		if (separator <= 0) return;
+		cookieMap.set(cookie.slice(0, separator).trim(), cookie.trim());
+	};
+
+	String(existingCookie || '').split(';').map(cookie => cookie.trim()).filter(Boolean).forEach(addCookie);
+	normalizeSetCookieHeaders(setCookie).forEach(addCookie);
+	return Array.from(cookieMap.values()).join('; ');
+}
+
 // my own implementation to keep track of the value on errors, for debugging
 function promisify(fun) {
 	return (function () {
@@ -301,13 +328,22 @@ class AlexaRemoteExt extends AlexaRemote {
 			throw new Error('Missing amazonPage/alexaServiceHost for Alexa SPA URL (both options and _options are empty)');
 		}
 
+		const existingCookie = this.cookie
+			|| (existingStructuredCookieData && existingStructuredCookieData.localCookie)
+			|| getHeader(primaryOptions.headers, 'Cookie')
+			|| getHeader(legacyOptions.headers, 'Cookie');
+		const spaHeaders = {
+			'User-Agent': primaryOptions.userAgent || legacyOptions.userAgent,
+			'Accept-Language': primaryOptions.acceptLanguage || legacyOptions.acceptLanguage || 'de-DE'
+		};
+		if (existingCookie) {
+			spaHeaders.Cookie = existingCookie;
+		}
+
 		const res = await this.auth.request({
 			method: 'GET',
 			url: `https://${spaHost}/spa/index.html`,
-			headers: {
-				'User-Agent': primaryOptions.userAgent || legacyOptions.userAgent,
-				'Accept-Language': primaryOptions.acceptLanguage || legacyOptions.acceptLanguage || 'de-DE'
-			},
+			headers: spaHeaders,
 			followRedirect: true
 		});
 
@@ -320,11 +356,12 @@ class AlexaRemoteExt extends AlexaRemote {
         	throw new Error('No Alexa cookies received');
     	}
 
-		const refreshedCookie = setCookie.map(c => c.split(';')[0]).join('; ');
-		const refreshedCsrf = this._extractCsrf(refreshedCookie);
+		const responseCookie = normalizeSetCookieHeaders(setCookie).join('; ');
+		const refreshedCsrf = this._extractCsrf(responseCookie);
 		if (!refreshedCsrf) {
-			return;
+			throw new Error('Alexa SPA cookies did not include csrf');
 		}
+		const refreshedCookie = mergeCookieStrings(existingCookie, setCookie);
 
 		this.cookie = refreshedCookie;
 		this.csrf = refreshedCsrf;

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -323,7 +323,7 @@ class AlexaRemoteExt extends AlexaRemote {
     	this.cookie = setCookie.map(c => c.split(';')[0]).join('; ');
     	this.csrf = this._extractCsrf(this.cookie);
 
-		if (existingStructuredCookieData) {
+		if (this.csrf && existingStructuredCookieData) {
 			const refreshedCookieData = Object.assign({}, existingStructuredCookieData, {
 				localCookie: this.cookie,
 				csrf: this.csrf

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -281,41 +281,30 @@ class AlexaRemoteExt extends AlexaRemote {
 		const existingStructuredCookieData = tokenRegistrationData
 			|| [primaryOptions.cookie, legacyOptions.cookie, this.cookieData]
 				.find(cookieData => tools.isObject(cookieData));
-		const previousRefreshState = {
-			cookie: this.cookie,
-			csrf: this.csrf,
-			macDms: this.macDms,
-			cookieData: this.cookieData,
-			primaryCookie: primaryOptions.cookie,
-			legacyCookie: legacyOptions.cookie,
-			primaryMacDms: primaryOptions.macDms,
-			legacyMacDms: legacyOptions.macDms,
-			primaryFormerRegistrationData: primaryOptions.formerRegistrationData,
-			legacyFormerRegistrationData: legacyOptions.formerRegistrationData,
-			primaryHeadersCookie: primaryOptions.headers && primaryOptions.headers.Cookie,
-			primaryHeadersCsrf: primaryOptions.headers && primaryOptions.headers['csrf'],
-			legacyHeadersCookie: legacyOptions.headers && legacyOptions.headers.Cookie,
-			legacyHeadersCsrf: legacyOptions.headers && legacyOptions.headers['csrf'],
-		};
+		const snapshotProperty = (target, property) => ({
+			target,
+			property,
+			hasOwn: !!target && Object.prototype.hasOwnProperty.call(target, property),
+			value: target && target[property],
+		});
+		const snapshotProperties = (target, properties) => properties.map(property => snapshotProperty(target, property));
+		const refreshStateSnapshots = [
+			...snapshotProperties(this, ['cookie', 'csrf', 'macDms', 'cookieData']),
+			...snapshotProperties(primaryOptions, ['cookie', 'csrf', 'macDms', 'formerRegistrationData']),
+			...snapshotProperties(legacyOptions, ['cookie', 'csrf', 'macDms', 'formerRegistrationData']),
+			...snapshotProperties(primaryOptions.headers, ['Cookie', 'csrf']),
+			...snapshotProperties(legacyOptions.headers, ['Cookie', 'csrf']),
+		];
 		const restoreRefreshState = () => {
-			this.cookie = previousRefreshState.cookie;
-			this.csrf = previousRefreshState.csrf;
-			this.macDms = previousRefreshState.macDms;
-			this.cookieData = previousRefreshState.cookieData;
-			primaryOptions.cookie = previousRefreshState.primaryCookie;
-			legacyOptions.cookie = previousRefreshState.legacyCookie;
-			primaryOptions.macDms = previousRefreshState.primaryMacDms;
-			legacyOptions.macDms = previousRefreshState.legacyMacDms;
-			primaryOptions.formerRegistrationData = previousRefreshState.primaryFormerRegistrationData;
-			legacyOptions.formerRegistrationData = previousRefreshState.legacyFormerRegistrationData;
-			if (primaryOptions.headers) {
-				primaryOptions.headers.Cookie = previousRefreshState.primaryHeadersCookie;
-				primaryOptions.headers['csrf'] = previousRefreshState.primaryHeadersCsrf;
-			}
-			if (legacyOptions.headers) {
-				legacyOptions.headers.Cookie = previousRefreshState.legacyHeadersCookie;
-				legacyOptions.headers['csrf'] = previousRefreshState.legacyHeadersCsrf;
-			}
+			refreshStateSnapshots.forEach(snapshot => {
+				if (!snapshot.target) return;
+				if (snapshot.hasOwn) {
+					snapshot.target[snapshot.property] = snapshot.value;
+				}
+				else {
+					delete snapshot.target[snapshot.property];
+				}
+			});
 		};
 
 		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.

--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -320,8 +320,14 @@ class AlexaRemoteExt extends AlexaRemote {
         	throw new Error('No Alexa cookies received');
     	}
 
-    	this.cookie = setCookie.map(c => c.split(';')[0]).join('; ');
-    	this.csrf = this._extractCsrf(this.cookie);
+		const refreshedCookie = setCookie.map(c => c.split(';')[0]).join('; ');
+		const refreshedCsrf = this._extractCsrf(refreshedCookie);
+		if (!refreshedCsrf) {
+			return;
+		}
+
+		this.cookie = refreshedCookie;
+		this.csrf = refreshedCsrf;
 
 		if (this.csrf && existingStructuredCookieData) {
 			const refreshedCookieData = Object.assign({}, existingStructuredCookieData, {

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -42,7 +42,7 @@ async function main() {
 		const AlexaRemoteExt = require('../lib/alexa-remote-ext');
 		const existingCookieData = {
 			loginCookie: 'login-cookie',
-			localCookie: 'csrf=old-csrf; session-id=old-session',
+			localCookie: 'csrf=old-csrf; session-id=old-session; ubid-main=old-ubid',
 			csrf: 'old-csrf',
 			refreshToken: 'refresh-token',
 			accessToken: 'access-token',
@@ -71,19 +71,23 @@ async function main() {
 			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
 		};
 		alexa.auth = {
-			request: async () => ({
-				headers: {
-					'set-cookie': [
-						'csrf=new-csrf; Path=/; Secure',
-						'session-id=new-session; Path=/; Secure',
-					],
-				},
-			}),
+			request: async requestOptions => {
+				assert.strictEqual(requestOptions.headers.Cookie, 'csrf=old-csrf; session-id=old-session; ubid-main=old-ubid');
+				return {
+					headers: {
+						'set-cookie': [
+							'csrf=new-csrf; Path=/; Secure',
+							'session-id=new-session; Path=/; Secure',
+							'new-cookie=new-value; Path=/; Secure',
+						],
+					},
+				};
+			},
 		};
 
 		await alexa.refreshAlexaCookies();
 
-		assert.strictEqual(alexa.cookie, 'csrf=new-csrf; session-id=new-session');
+		assert.strictEqual(alexa.cookie, 'csrf=new-csrf; session-id=new-session; ubid-main=old-ubid; new-cookie=new-value');
 		assert.strictEqual(alexa.csrf, 'new-csrf');
 		assert.strictEqual(alexa.cookieData.loginCookie, existingCookieData.loginCookie);
 		assert.strictEqual(alexa.cookieData.refreshToken, existingCookieData.refreshToken);
@@ -97,7 +101,7 @@ async function main() {
 		assert.strictEqual(alexa._options.cookie, alexa.cookieData);
 		assert.strictEqual(alexa._options.formerRegistrationData, alexa.cookieData);
 		assert.deepStrictEqual(cookieEvents, [{
-			cookie: 'csrf=new-csrf; session-id=new-session',
+			cookie: 'csrf=new-csrf; session-id=new-session; ubid-main=old-ubid; new-cookie=new-value',
 			csrf: 'new-csrf',
 			macDms: 'mac-dms',
 		}]);
@@ -126,14 +130,17 @@ async function main() {
 			runtimeEvents.push({ cookie, csrf, macDms });
 		});
 		runtimeAlexa.auth = {
-			request: async () => ({
-				headers: {
-					'set-cookie': [
-						'csrf=runtime-csrf; Path=/; Secure',
-						'session-id=runtime-session; Path=/; Secure',
-					],
-				},
-			}),
+			request: async requestOptions => {
+				assert.strictEqual(requestOptions.headers.Cookie, runtimeCookieData.localCookie);
+				return {
+					headers: {
+						'set-cookie': [
+							'csrf=runtime-csrf; Path=/; Secure',
+							'session-id=runtime-session; Path=/; Secure',
+						],
+					},
+				};
+			},
 		};
 
 		await runtimeAlexa.refreshAlexaCookies();
@@ -182,16 +189,22 @@ async function main() {
 			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
 		};
 		noCsrfAlexa.auth = {
-			request: async () => ({
-				headers: {
-					'set-cookie': [
-						'session-id=new-session; Path=/; Secure',
-					],
-				},
-			}),
+			request: async requestOptions => {
+				assert.strictEqual(requestOptions.headers.Cookie, noCsrfCookieData.localCookie);
+				return {
+					headers: {
+						'set-cookie': [
+							'session-id=new-session; Path=/; Secure',
+						],
+					},
+				};
+			},
 		};
 
-		await noCsrfAlexa.refreshAlexaCookies();
+		await assert.rejects(
+			() => noCsrfAlexa.refreshAlexaCookies(),
+			/Alexa SPA cookies did not include csrf/
+		);
 
 		assert.deepStrictEqual(noCsrfEvents, []);
 		assert.strictEqual(noCsrfAlexa.cookie, noCsrfCookieData.localCookie);

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -1,0 +1,103 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const Module = require('module');
+
+const originalLoad = Module._load;
+
+class FakeAlexaRemote extends EventEmitter {
+	constructor(options = {}) {
+		super();
+		this._options = options;
+		this.cookieData = options.cookie;
+	}
+
+	setCookie(cookieData) {
+		this.cookieData = cookieData;
+		this.cookie = cookieData.localCookie;
+		this.csrf = cookieData.csrf;
+	}
+}
+
+Module._load = function patchedLoad(request, parent, isMain) {
+	if (request === 'alexa-remote2') {
+		return FakeAlexaRemote;
+	}
+	if (request === 'tough-cookie') {
+		return { CookieJar: class CookieJar {} };
+	}
+	if (request === './auth/auth-controller') {
+		return { AlexaAuthController: class AlexaAuthController {} };
+	}
+	if (request === './auth/token-store') {
+		return { TokenStore: class TokenStore {} };
+	}
+	if (request === './auth/oauth-device') {
+		return { OAuthDevice: class OAuthDevice {} };
+	}
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+async function main() {
+	try {
+		const AlexaRemoteExt = require('../lib/alexa-remote-ext');
+		const existingCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			accessToken: 'access-token',
+			macDms: 'mac-dms',
+			amazonPage: 'amazon.com',
+			dataVersion: 2,
+		};
+		const options = {
+			cookie: existingCookieData,
+			amazonPage: 'amazon.com',
+			userAgent: 'test-agent',
+			acceptLanguage: 'en-US',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const alexa = new AlexaRemoteExt(options);
+		alexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
+		};
+		alexa.auth = {
+			request: async () => ({
+				headers: {
+					'set-cookie': [
+						'csrf=new-csrf; Path=/; Secure',
+						'session-id=new-session; Path=/; Secure',
+					],
+				},
+			}),
+		};
+
+		await alexa.refreshAlexaCookies();
+
+		assert.strictEqual(alexa.cookie, 'csrf=new-csrf; session-id=new-session');
+		assert.strictEqual(alexa.csrf, 'new-csrf');
+		assert.strictEqual(alexa.cookieData.loginCookie, existingCookieData.loginCookie);
+		assert.strictEqual(alexa.cookieData.refreshToken, existingCookieData.refreshToken);
+		assert.strictEqual(alexa.cookieData.accessToken, existingCookieData.accessToken);
+		assert.strictEqual(alexa.cookieData.macDms, existingCookieData.macDms);
+		assert.strictEqual(alexa.cookieData.amazonPage, existingCookieData.amazonPage);
+		assert.strictEqual(alexa.cookieData.dataVersion, existingCookieData.dataVersion);
+		assert.strictEqual(alexa.cookieData.localCookie, alexa.cookie);
+		assert.strictEqual(alexa.cookieData.csrf, alexa.csrf);
+		assert.strictEqual(options.cookie, alexa.cookieData);
+		assert.strictEqual(alexa._options.cookie, alexa.cookieData);
+	}
+	finally {
+		Module._load = originalLoad;
+	}
+}
+
+main().catch(error => {
+	console.error(error);
+	process.exit(1);
+});

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -63,6 +63,10 @@ async function main() {
 			},
 		};
 		const alexa = new AlexaRemoteExt(options);
+		const cookieEvents = [];
+		alexa.on('cookie', (cookie, csrf, macDms) => {
+			cookieEvents.push({ cookie, csrf, macDms });
+		});
 		alexa.alexaCookie = {
 			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
 		};
@@ -91,6 +95,60 @@ async function main() {
 		assert.strictEqual(alexa.cookieData.csrf, alexa.csrf);
 		assert.strictEqual(options.cookie, alexa.cookieData);
 		assert.strictEqual(alexa._options.cookie, alexa.cookieData);
+		assert.strictEqual(alexa._options.formerRegistrationData, alexa.cookieData);
+		assert.deepStrictEqual(cookieEvents, [{
+			cookie: 'csrf=new-csrf; session-id=new-session',
+			csrf: 'new-csrf',
+			macDms: 'mac-dms',
+		}]);
+
+		const runtimeCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'runtime-mac-dms',
+		};
+		const runtimeOptions = {
+			cookie: runtimeCookieData.localCookie,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const runtimeAlexa = new AlexaRemoteExt(runtimeOptions);
+		runtimeAlexa.cookieData = runtimeCookieData;
+		const runtimeEvents = [];
+		runtimeAlexa.on('cookie', (cookie, csrf, macDms) => {
+			runtimeEvents.push({ cookie, csrf, macDms });
+		});
+		runtimeAlexa.auth = {
+			request: async () => ({
+				headers: {
+					'set-cookie': [
+						'csrf=runtime-csrf; Path=/; Secure',
+						'session-id=runtime-session; Path=/; Secure',
+					],
+				},
+			}),
+		};
+
+		await runtimeAlexa.refreshAlexaCookies();
+
+		assert.deepStrictEqual(runtimeEvents, [{
+			cookie: 'csrf=runtime-csrf; session-id=runtime-session',
+			csrf: 'runtime-csrf',
+			macDms: 'runtime-mac-dms',
+		}]);
+		assert.strictEqual(runtimeAlexa.cookieData.loginCookie, runtimeCookieData.loginCookie);
+		assert.strictEqual(runtimeAlexa.cookieData.refreshToken, runtimeCookieData.refreshToken);
+		assert.strictEqual(runtimeAlexa.cookieData.localCookie, 'csrf=runtime-csrf; session-id=runtime-session');
+		assert.strictEqual(runtimeAlexa.cookieData.csrf, 'runtime-csrf');
+		assert.strictEqual(runtimeAlexa._options.cookie, runtimeAlexa.cookieData);
+		assert.strictEqual(runtimeAlexa._options.formerRegistrationData, runtimeAlexa.cookieData);
 	}
 	finally {
 		Module._load = originalLoad;

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -15,6 +15,24 @@ class FakeAlexaRemote extends EventEmitter {
 		this.cookieData = cookieData;
 		this.cookie = cookieData.localCookie;
 		this.csrf = cookieData.csrf;
+		if (this.options) this.options.csrf = this.csrf;
+		if (this._options) this._options.csrf = this.csrf;
+	}
+}
+
+const hasOwn = (object, property) => Object.prototype.hasOwnProperty.call(object, property);
+
+function ownState(object, property) {
+	return {
+		hasOwn: hasOwn(object, property),
+		value: object[property],
+	};
+}
+
+function assertOwnState(object, property, expected, label) {
+	assert.strictEqual(hasOwn(object, property), expected.hasOwn, `${label} own property`);
+	if (expected.hasOwn) {
+		assert.strictEqual(object[property], expected.value, `${label} value`);
 	}
 }
 
@@ -400,6 +418,127 @@ async function main() {
 		assert.strictEqual(partialEmptySetCookieAlexa.macDms, partialEmptySetCookieData.macDms);
 		assert.strictEqual(partialEmptySetCookieOptions.cookie, partialEmptySetCookieData);
 		assert.strictEqual(partialEmptySetCookieAlexa._options.cookie, partialEmptySetCookieData);
+
+		const csrfRestoreCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'old-mac-dms',
+		};
+		const csrfRestoreOptions = {
+			cookie: csrfRestoreCookieData,
+			csrf: 'primary-old-csrf',
+			amazonPage: 'amazon.com',
+			headers: {
+				Cookie: 'primary-old-cookie',
+				csrf: 'primary-header-csrf',
+			},
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const csrfRestoreLegacyOptions = {
+			cookie: csrfRestoreCookieData,
+			csrf: 'legacy-old-csrf',
+			headers: {
+				Cookie: 'legacy-old-cookie',
+				csrf: 'legacy-header-csrf',
+			},
+			formerRegistrationData: csrfRestoreCookieData,
+			macDms: 'legacy-old-mac-dms',
+		};
+		const csrfRestoreAlexa = new AlexaRemoteExt(csrfRestoreOptions);
+		csrfRestoreAlexa._options = csrfRestoreLegacyOptions;
+		csrfRestoreAlexa.cookie = csrfRestoreCookieData.localCookie;
+		csrfRestoreAlexa.csrf = csrfRestoreCookieData.csrf;
+		csrfRestoreAlexa.macDms = csrfRestoreCookieData.macDms;
+		const csrfRestoreBefore = {
+			primaryCsrf: ownState(csrfRestoreOptions, 'csrf'),
+			legacyCsrf: ownState(csrfRestoreLegacyOptions, 'csrf'),
+			primaryHeaderCookie: ownState(csrfRestoreOptions.headers, 'Cookie'),
+			primaryHeaderCsrf: ownState(csrfRestoreOptions.headers, 'csrf'),
+			legacyHeaderCookie: ownState(csrfRestoreLegacyOptions.headers, 'Cookie'),
+			legacyHeaderCsrf: ownState(csrfRestoreLegacyOptions.headers, 'csrf'),
+		};
+		csrfRestoreAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(null, badNativeRefresh),
+		};
+		csrfRestoreAlexa.auth = {
+			request: async () => ({ headers: { 'set-cookie': [] } }),
+		};
+
+		await assert.rejects(
+			() => csrfRestoreAlexa.refreshAlexaCookies(),
+			/No Alexa cookies received/
+		);
+		assertOwnState(csrfRestoreOptions, 'csrf', csrfRestoreBefore.primaryCsrf, 'primary options csrf');
+		assertOwnState(csrfRestoreLegacyOptions, 'csrf', csrfRestoreBefore.legacyCsrf, 'legacy options csrf');
+		assertOwnState(csrfRestoreOptions.headers, 'Cookie', csrfRestoreBefore.primaryHeaderCookie, 'primary header Cookie');
+		assertOwnState(csrfRestoreOptions.headers, 'csrf', csrfRestoreBefore.primaryHeaderCsrf, 'primary header csrf');
+		assertOwnState(csrfRestoreLegacyOptions.headers, 'Cookie', csrfRestoreBefore.legacyHeaderCookie, 'legacy header Cookie');
+		assertOwnState(csrfRestoreLegacyOptions.headers, 'csrf', csrfRestoreBefore.legacyHeaderCsrf, 'legacy header csrf');
+
+		const propertyShapeCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=shape-old-csrf; session-id=shape-old-session',
+			csrf: 'shape-old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'shape-old-mac-dms',
+		};
+		const propertyShapeOptions = {
+			cookie: propertyShapeCookieData,
+			amazonPage: 'amazon.com',
+			headers: {},
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const propertyShapeLegacyOptions = {
+			cookie: propertyShapeCookieData,
+			csrf: undefined,
+			headers: {
+				Cookie: undefined,
+				csrf: undefined,
+			},
+			formerRegistrationData: propertyShapeCookieData,
+		};
+		const propertyShapeAlexa = new AlexaRemoteExt(propertyShapeOptions);
+		propertyShapeAlexa._options = propertyShapeLegacyOptions;
+		propertyShapeAlexa.cookie = propertyShapeCookieData.localCookie;
+		propertyShapeAlexa.csrf = propertyShapeCookieData.csrf;
+		propertyShapeAlexa.macDms = propertyShapeCookieData.macDms;
+		const propertyShapeBefore = {
+			primaryCsrf: ownState(propertyShapeOptions, 'csrf'),
+			legacyCsrf: ownState(propertyShapeLegacyOptions, 'csrf'),
+			primaryHeaderCookie: ownState(propertyShapeOptions.headers, 'Cookie'),
+			primaryHeaderCsrf: ownState(propertyShapeOptions.headers, 'csrf'),
+			legacyHeaderCookie: ownState(propertyShapeLegacyOptions.headers, 'Cookie'),
+			legacyHeaderCsrf: ownState(propertyShapeLegacyOptions.headers, 'csrf'),
+		};
+		propertyShapeAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(null, badNativeRefresh),
+		};
+		propertyShapeAlexa.auth = {
+			request: async () => ({}),
+		};
+
+		await assert.rejects(
+			() => propertyShapeAlexa.refreshAlexaCookies(),
+			/No response headers from Alexa SPA/
+		);
+		assertOwnState(propertyShapeOptions, 'csrf', propertyShapeBefore.primaryCsrf, 'missing primary options csrf');
+		assertOwnState(propertyShapeLegacyOptions, 'csrf', propertyShapeBefore.legacyCsrf, 'undefined legacy options csrf');
+		assertOwnState(propertyShapeOptions.headers, 'Cookie', propertyShapeBefore.primaryHeaderCookie, 'missing primary header Cookie');
+		assertOwnState(propertyShapeOptions.headers, 'csrf', propertyShapeBefore.primaryHeaderCsrf, 'missing primary header csrf');
+		assertOwnState(propertyShapeLegacyOptions.headers, 'Cookie', propertyShapeBefore.legacyHeaderCookie, 'undefined legacy header Cookie');
+		assertOwnState(propertyShapeLegacyOptions.headers, 'csrf', propertyShapeBefore.legacyHeaderCsrf, 'undefined legacy header csrf');
 	}
 	finally {
 		Module._load = originalLoad;

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -292,6 +292,7 @@ async function main() {
 		const partialRefreshAlexa = new AlexaRemoteExt(partialRefreshOptions);
 		partialRefreshAlexa.cookie = partialRefreshCookieData.localCookie;
 		partialRefreshAlexa.csrf = partialRefreshCookieData.csrf;
+		partialRefreshAlexa.macDms = partialRefreshCookieData.macDms;
 		const badNativeRefresh = {
 			loginCookie: 'login-cookie',
 			localCookie: 'session-id=partial-session',
@@ -318,8 +319,87 @@ async function main() {
 		assert.strictEqual(partialRefreshAlexa.cookie, partialRefreshCookieData.localCookie);
 		assert.strictEqual(partialRefreshAlexa.csrf, partialRefreshCookieData.csrf);
 		assert.strictEqual(partialRefreshAlexa.cookieData, partialRefreshCookieData);
+		assert.strictEqual(partialRefreshAlexa.macDms, partialRefreshCookieData.macDms);
 		assert.strictEqual(partialRefreshOptions.cookie, partialRefreshCookieData);
 		assert.strictEqual(partialRefreshAlexa._options.cookie, partialRefreshCookieData);
+
+		const partialMissingHeadersCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'old-mac-dms',
+		};
+		const partialMissingHeadersOptions = {
+			cookie: partialMissingHeadersCookieData,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const partialMissingHeadersAlexa = new AlexaRemoteExt(partialMissingHeadersOptions);
+		partialMissingHeadersAlexa.cookie = partialMissingHeadersCookieData.localCookie;
+		partialMissingHeadersAlexa.csrf = partialMissingHeadersCookieData.csrf;
+		partialMissingHeadersAlexa.macDms = partialMissingHeadersCookieData.macDms;
+		partialMissingHeadersAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(null, badNativeRefresh),
+		};
+		partialMissingHeadersAlexa.auth = {
+			request: async () => ({}),
+		};
+
+		await assert.rejects(
+			() => partialMissingHeadersAlexa.refreshAlexaCookies(),
+			/No response headers from Alexa SPA/
+		);
+		assert.strictEqual(partialMissingHeadersAlexa.cookie, partialMissingHeadersCookieData.localCookie);
+		assert.strictEqual(partialMissingHeadersAlexa.csrf, partialMissingHeadersCookieData.csrf);
+		assert.strictEqual(partialMissingHeadersAlexa.cookieData, partialMissingHeadersCookieData);
+		assert.strictEqual(partialMissingHeadersAlexa.macDms, partialMissingHeadersCookieData.macDms);
+		assert.strictEqual(partialMissingHeadersOptions.cookie, partialMissingHeadersCookieData);
+		assert.strictEqual(partialMissingHeadersAlexa._options.cookie, partialMissingHeadersCookieData);
+
+		const partialEmptySetCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'old-mac-dms',
+		};
+		const partialEmptySetCookieOptions = {
+			cookie: partialEmptySetCookieData,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const partialEmptySetCookieAlexa = new AlexaRemoteExt(partialEmptySetCookieOptions);
+		partialEmptySetCookieAlexa.cookie = partialEmptySetCookieData.localCookie;
+		partialEmptySetCookieAlexa.csrf = partialEmptySetCookieData.csrf;
+		partialEmptySetCookieAlexa.macDms = partialEmptySetCookieData.macDms;
+		partialEmptySetCookieAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(null, badNativeRefresh),
+		};
+		partialEmptySetCookieAlexa.auth = {
+			request: async () => ({ headers: { 'set-cookie': [] } }),
+		};
+
+		await assert.rejects(
+			() => partialEmptySetCookieAlexa.refreshAlexaCookies(),
+			/No Alexa cookies received/
+		);
+		assert.strictEqual(partialEmptySetCookieAlexa.cookie, partialEmptySetCookieData.localCookie);
+		assert.strictEqual(partialEmptySetCookieAlexa.csrf, partialEmptySetCookieData.csrf);
+		assert.strictEqual(partialEmptySetCookieAlexa.cookieData, partialEmptySetCookieData);
+		assert.strictEqual(partialEmptySetCookieAlexa.macDms, partialEmptySetCookieData.macDms);
+		assert.strictEqual(partialEmptySetCookieOptions.cookie, partialEmptySetCookieData);
+		assert.strictEqual(partialEmptySetCookieAlexa._options.cookie, partialEmptySetCookieData);
 	}
 	finally {
 		Module._load = originalLoad;

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -149,6 +149,51 @@ async function main() {
 		assert.strictEqual(runtimeAlexa.cookieData.csrf, 'runtime-csrf');
 		assert.strictEqual(runtimeAlexa._options.cookie, runtimeAlexa.cookieData);
 		assert.strictEqual(runtimeAlexa._options.formerRegistrationData, runtimeAlexa.cookieData);
+
+		const noCsrfCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'mac-dms',
+		};
+		const noCsrfOptions = {
+			cookie: noCsrfCookieData,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const noCsrfAlexa = new AlexaRemoteExt(noCsrfOptions);
+		const noCsrfEvents = [];
+		noCsrfAlexa.on('cookie', (cookie, csrf, macDms) => {
+			noCsrfEvents.push({ cookie, csrf, macDms });
+		});
+		noCsrfAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
+		};
+		noCsrfAlexa.auth = {
+			request: async () => ({
+				headers: {
+					'set-cookie': [
+						'session-id=new-session; Path=/; Secure',
+					],
+				},
+			}),
+		};
+
+		await noCsrfAlexa.refreshAlexaCookies();
+
+		assert.deepStrictEqual(noCsrfEvents, []);
+		assert.strictEqual(noCsrfAlexa.cookie, 'session-id=new-session');
+		assert.strictEqual(noCsrfAlexa.csrf, null);
+		assert.strictEqual(noCsrfAlexa.cookieData, noCsrfCookieData);
+		assert.strictEqual(noCsrfAlexa._options.cookie, noCsrfCookieData);
+		assert.strictEqual(noCsrfAlexa._options.headers.Cookie, 'session-id=new-session');
+		assert.strictEqual(noCsrfAlexa._options.headers.csrf, null);
 	}
 	finally {
 		Module._load = originalLoad;

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -213,6 +213,113 @@ async function main() {
 		assert.strictEqual(noCsrfAlexa._options.cookie, noCsrfCookieData);
 		assert.strictEqual(noCsrfAlexa._options.headers.Cookie, noCsrfCookieData.localCookie);
 		assert.strictEqual(noCsrfAlexa._options.headers.csrf, noCsrfCookieData.csrf);
+
+		const missingUserAgentCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+		};
+		const missingUserAgentAlexa = new AlexaRemoteExt({
+			cookie: missingUserAgentCookieData,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		});
+		missingUserAgentAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
+		};
+		missingUserAgentAlexa.auth = {
+			request: async requestOptions => {
+				assert(!Object.prototype.hasOwnProperty.call(requestOptions.headers, 'User-Agent'));
+				assert.strictEqual(requestOptions.headers.Cookie, missingUserAgentCookieData.localCookie);
+				return {
+					headers: {
+						'set-cookie': [
+							'csrf=fresh-csrf; Path=/; Secure',
+						],
+					},
+				};
+			},
+		};
+
+		await missingUserAgentAlexa.refreshAlexaCookies();
+		assert.strictEqual(missingUserAgentAlexa.cookie, 'csrf=fresh-csrf; session-id=old-session');
+
+		const emptySetCookieAlexa = new AlexaRemoteExt({
+			cookie: missingUserAgentCookieData,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		});
+		emptySetCookieAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(new Error('token refresh failed')),
+		};
+		emptySetCookieAlexa.auth = {
+			request: async () => ({ headers: { 'set-cookie': [] } }),
+		};
+
+		await assert.rejects(
+			() => emptySetCookieAlexa.refreshAlexaCookies(),
+			/No Alexa cookies received/
+		);
+
+		const partialRefreshCookieData = {
+			loginCookie: 'login-cookie',
+			localCookie: 'csrf=old-csrf; session-id=old-session',
+			csrf: 'old-csrf',
+			refreshToken: 'refresh-token',
+			macDms: 'old-mac-dms',
+		};
+		const partialRefreshOptions = {
+			cookie: partialRefreshCookieData,
+			amazonPage: 'amazon.com',
+			context: {
+				global: {
+					get: () => null,
+					set: () => {},
+				},
+			},
+		};
+		const partialRefreshAlexa = new AlexaRemoteExt(partialRefreshOptions);
+		partialRefreshAlexa.cookie = partialRefreshCookieData.localCookie;
+		partialRefreshAlexa.csrf = partialRefreshCookieData.csrf;
+		const badNativeRefresh = {
+			loginCookie: 'login-cookie',
+			localCookie: 'session-id=partial-session',
+			refreshToken: 'refresh-token',
+			macDms: 'partial-mac-dms',
+		};
+		partialRefreshAlexa.alexaCookie = {
+			refreshAlexaCookie: (refreshOptions, callback) => callback(null, badNativeRefresh),
+		};
+		partialRefreshAlexa.auth = {
+			request: async () => ({
+				headers: {
+					'set-cookie': [
+						'session-id=new-session; Path=/; Secure',
+					],
+				},
+			}),
+		};
+
+		await assert.rejects(
+			() => partialRefreshAlexa.refreshAlexaCookies(),
+			/Alexa SPA cookies did not include csrf/
+		);
+		assert.strictEqual(partialRefreshAlexa.cookie, partialRefreshCookieData.localCookie);
+		assert.strictEqual(partialRefreshAlexa.csrf, partialRefreshCookieData.csrf);
+		assert.strictEqual(partialRefreshAlexa.cookieData, partialRefreshCookieData);
+		assert.strictEqual(partialRefreshOptions.cookie, partialRefreshCookieData);
+		assert.strictEqual(partialRefreshAlexa._options.cookie, partialRefreshCookieData);
 	}
 	finally {
 		Module._load = originalLoad;

--- a/test/spa-refresh-cookie-data.test.js
+++ b/test/spa-refresh-cookie-data.test.js
@@ -160,6 +160,10 @@ async function main() {
 		const noCsrfOptions = {
 			cookie: noCsrfCookieData,
 			amazonPage: 'amazon.com',
+			headers: {
+				Cookie: noCsrfCookieData.localCookie,
+				csrf: noCsrfCookieData.csrf,
+			},
 			context: {
 				global: {
 					get: () => null,
@@ -168,6 +172,8 @@ async function main() {
 			},
 		};
 		const noCsrfAlexa = new AlexaRemoteExt(noCsrfOptions);
+		noCsrfAlexa.cookie = noCsrfCookieData.localCookie;
+		noCsrfAlexa.csrf = noCsrfCookieData.csrf;
 		const noCsrfEvents = [];
 		noCsrfAlexa.on('cookie', (cookie, csrf, macDms) => {
 			noCsrfEvents.push({ cookie, csrf, macDms });
@@ -188,12 +194,12 @@ async function main() {
 		await noCsrfAlexa.refreshAlexaCookies();
 
 		assert.deepStrictEqual(noCsrfEvents, []);
-		assert.strictEqual(noCsrfAlexa.cookie, 'session-id=new-session');
-		assert.strictEqual(noCsrfAlexa.csrf, null);
+		assert.strictEqual(noCsrfAlexa.cookie, noCsrfCookieData.localCookie);
+		assert.strictEqual(noCsrfAlexa.csrf, noCsrfCookieData.csrf);
 		assert.strictEqual(noCsrfAlexa.cookieData, noCsrfCookieData);
 		assert.strictEqual(noCsrfAlexa._options.cookie, noCsrfCookieData);
-		assert.strictEqual(noCsrfAlexa._options.headers.Cookie, 'session-id=new-session');
-		assert.strictEqual(noCsrfAlexa._options.headers.csrf, null);
+		assert.strictEqual(noCsrfAlexa._options.headers.Cookie, noCsrfCookieData.localCookie);
+		assert.strictEqual(noCsrfAlexa._options.headers.csrf, noCsrfCookieData.csrf);
 	}
 	finally {
 		Module._load = originalLoad;

--- a/test/token-refresh-registration-data.test.js
+++ b/test/token-refresh-registration-data.test.js
@@ -1,0 +1,109 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const Module = require('module');
+
+class FakeAlexaRemote extends EventEmitter {
+	constructor() {
+		super();
+		this.cookie = null;
+		this.csrf = null;
+		this.cookieData = null;
+		this._options = {};
+	}
+
+	setCookie(cookie) {
+		if (cookie && cookie.localCookie) {
+			this.cookie = cookie.localCookie;
+			this.cookieData = cookie;
+			this._options.formerRegistrationData = cookie;
+		} else {
+			this.cookie = cookie;
+		}
+
+		const match = this.cookie && this.cookie.match(/csrf=([^;]+)/);
+		if (match) this.csrf = match[1];
+		this._options.cookie = this.cookie;
+		this._options.csrf = this.csrf;
+	}
+}
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+	if (request === 'alexa-remote2') return FakeAlexaRemote;
+	if (request === 'tough-cookie') return { CookieJar: class CookieJar {} };
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+const AlexaRemoteExt = require('../lib/alexa-remote-ext.js');
+Module._load = originalLoad;
+
+function createCookieData(overrides) {
+	return Object.assign({
+		loginCookie: 'login-cookie',
+		localCookie: 'csrf=old-csrf; session=old-session',
+		refreshToken: 'refresh-token',
+		accessToken: 'old-access-token',
+		macDms: 'mac-dms',
+		deviceSerial: 'device-serial',
+		deviceAppName: 'device-app-name',
+		amazonPage: 'amazon.com',
+		dataVersion: 2,
+		tokenDate: Date.now() - 48 * 60 * 60 * 1000,
+	}, overrides);
+}
+
+async function testUsesFormerRegistrationDataWhenCookieOptionIsString() {
+	const alexa = new AlexaRemoteExt({ context: { global: {} } });
+	const formerRegistrationData = createCookieData();
+	const refreshedCookieData = createCookieData({
+		loginCookie: 'new-login-cookie',
+		localCookie: 'csrf=new-csrf; session=new-session',
+		accessToken: 'new-access-token',
+		tokenDate: Date.now(),
+	});
+	let refreshOptions;
+	let refreshFormerRegistrationData;
+
+	alexa.options = {};
+	alexa._options = {
+		cookie: formerRegistrationData.localCookie,
+		formerRegistrationData,
+		headers: {},
+		amazonPage: 'amazon.com',
+	};
+	alexa.cookieData = formerRegistrationData;
+	alexa.alexaCookie = {
+		refreshAlexaCookie: (options, callback) => {
+			refreshOptions = options;
+			refreshFormerRegistrationData = options.formerRegistrationData;
+			callback(null, refreshedCookieData);
+		},
+	};
+	alexa.auth = {
+		request: () => {
+			throw new Error('SPA fallback should not be used');
+		},
+	};
+
+	await alexa.refreshAlexaCookies();
+
+	assert.strictEqual(refreshFormerRegistrationData, formerRegistrationData);
+	assert.strictEqual(refreshOptions.formerRegistrationData, refreshedCookieData);
+	assert.strictEqual(alexa.cookieData, refreshedCookieData);
+	assert.strictEqual(alexa.cookie, refreshedCookieData.localCookie);
+	assert.strictEqual(alexa.csrf, 'new-csrf');
+	assert.strictEqual(alexa._options.formerRegistrationData, refreshedCookieData);
+	assert.strictEqual(alexa.options.cookie, refreshedCookieData);
+	assert.strictEqual(alexa._options.cookie, refreshedCookieData.localCookie);
+	assert.strictEqual(alexa.options.headers.Cookie, refreshedCookieData.localCookie);
+	assert.strictEqual(alexa._options.headers.Cookie, refreshedCookieData.localCookie);
+}
+
+testUsesFormerRegistrationDataWhenCookieOptionIsString()
+	.then(() => {
+		console.log('token-refresh-registration-data tests passed');
+	})
+	.catch(error => {
+		console.error(error);
+		process.exitCode = 1;
+	});


### PR DESCRIPTION
### Problem

`refreshAlexaCookies()` has two refresh paths:

- token refresh through `alexa-cookie2`
- SPA fallback when token refresh fails

The token-refresh path writes the refreshed auth data back into `this.cookieData`, `options.cookie`, and `_options.cookie`. The SPA fallback only updated `this.cookie`, `this.csrf`, and request headers. If it received new cookies, the structured cookie data could still keep the previous `localCookie` and `csrf`. Any later code returning or persisting `cookieData` could therefore use stale cookie fields after a successful SPA fallback refresh.

### Change

After the SPA fallback receives `set-cookie` headers, it now updates the existing cookie data object with:

- `localCookie`
- `csrf`

It preserves the other existing fields, including `loginCookie`, `refreshToken`, `accessToken`, `macDms`, `amazonPage`, and `dataVersion`.

The updated object is assigned to:

- `this.cookieData`
- `options.cookie`
- `_options.cookie`

### Test

Added `test/spa-refresh-cookie-data.test.js`.

The test covers the fallback path where token refresh fails and the SPA request returns new cookies. It verifies that:

- `this.cookie` and `this.csrf` use the new SPA cookies
- `cookieData.localCookie` and `cookieData.csrf` are updated to the same values
- existing token/login metadata is preserved
- both option objects reference the updated cookie data

### Scope

This only keeps structured cookie data consistent after the existing SPA fallback succeeds. It does not change when refresh is triggered and does not change the token-refresh flow itself.

### Related issues

Related to #256.

This does not fully resolve #256. It is a small step in that direction: when the existing SPA fallback refresh succeeds, the refreshed cookie and CSRF values should also be reflected in the structured `cookieData` object that later return/persistence paths can use.

Without this, a successful fallback refresh could update the runtime request headers while leaving `cookieData.localCookie` and `cookieData.csrf` stale.