### PR TITLE
fix: use current cookie data during refresh

### DIFF
--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -544,8 +544,17 @@ module.exports = function (RED) {
 			if(this.state.code !== 'READY') throw new Error('account must be initialised before refreshing');
 			this.setState('REFRESH');
 
+			let cookieData;
+			if(this.authMethod === 'proxy'
+					&& !this.cookieFile
+					&& this.alexa
+					&& tools.isObject(this.alexa.cookieData)
+					&& this.alexa.cookieData.loginCookie) {
+				cookieData = this.alexa.cookieData;
+			}
+
 			//return this.alexa.refreshExt().then(value => {
-			return this.initAlexa(undefined).then(value => {
+			return this.initAlexa(cookieData).then(value => {
 				this.setState('READY');
 				this.renewTimeout();
 				return value;

--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -546,7 +546,6 @@ module.exports = function (RED) {
 
 			let cookieData;
 			if(this.authMethod === 'proxy'
-					&& !this.cookieFile
 					&& this.alexa
 					&& tools.isObject(this.alexa.cookieData)
 					&& this.alexa.cookieData.loginCookie) {

--- a/test/refresh-current-cookie-data.test.js
+++ b/test/refresh-current-cookie-data.test.js
@@ -122,16 +122,17 @@ async function testRefreshIgnoresCurrentCookieDataWithoutLoginCookie() {
 	assert.strictEqual(initInput, undefined);
 }
 
-async function testRefreshKeepsFileBasedProxyInputEmpty() {
+async function testRefreshUsesCurrentProxyCookieDataWithCookieFile() {
 	const account = createAccount({
 		authMethod: 'proxy',
 		cookieFile: '/tmp/alexa-cookie.json',
 	});
 
-	account.alexa.cookieData = createProxyCookieData();
+	const currentCookieData = createProxyCookieData();
+	account.alexa.cookieData = currentCookieData;
 	const initInput = await captureRefreshInitInput(account);
 
-	assert.strictEqual(initInput, undefined);
+	assert.deepStrictEqual(initInput, currentCookieData);
 }
 
 async function testRefreshKeepsCookieAuthInputEmpty() {
@@ -148,7 +149,7 @@ async function testRefreshKeepsCookieAuthInputEmpty() {
 Promise.resolve()
 	.then(testRefreshUsesCurrentProxyCookieData)
 	.then(testRefreshIgnoresCurrentCookieDataWithoutLoginCookie)
-	.then(testRefreshKeepsFileBasedProxyInputEmpty)
+	.then(testRefreshUsesCurrentProxyCookieDataWithCookieFile)
 	.then(testRefreshKeepsCookieAuthInputEmpty)
 	.then(() => {
 		console.log('refresh-current-cookie-data tests passed');

--- a/test/refresh-current-cookie-data.test.js
+++ b/test/refresh-current-cookie-data.test.js
@@ -1,0 +1,159 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const alexaRemotePath = path.join(repoRoot, 'lib', 'alexa-remote-ext.js');
+const accountNodePath = path.join(repoRoot, 'nodes', 'alexa-remote-account.js');
+
+class FakeAlexaRemote extends EventEmitter {
+	constructor() {
+		super();
+		this.cookieData = undefined;
+	}
+
+	setMaxListeners(value) {
+		super.setMaxListeners(value);
+		return this;
+	}
+
+	resetExt() {}
+}
+
+function loadAccountNode() {
+	delete require.cache[accountNodePath];
+	require.cache[alexaRemotePath] = {
+		id: alexaRemotePath,
+		filename: alexaRemotePath,
+		loaded: true,
+		exports: FakeAlexaRemote,
+	};
+
+	let AccountNode;
+	const RED = {
+		nodes: {
+			createNode(node) {
+				const emitter = new EventEmitter();
+				node.on = emitter.on.bind(emitter);
+				node.emit = emitter.emit.bind(emitter);
+				node.status = () => {};
+				node.log = () => {};
+				node.warn = () => {};
+				node.error = () => {};
+				node.debug = () => {};
+				node.context = () => ({});
+				node.credentials = {};
+			},
+			registerType(name, constructor) {
+				if (name === 'alexa-remote-account') AccountNode = constructor;
+			},
+		},
+		auth: {
+			needsPermission: () => () => {},
+		},
+		httpAdmin: {
+			get: () => {},
+		},
+	};
+
+	require(accountNodePath)(RED);
+	assert(AccountNode, 'Account node was not registered');
+	return AccountNode;
+}
+
+function createAccount(input) {
+	const AccountNode = loadAccountNode();
+	return new AccountNode(Object.assign({
+		refreshInterval: '',
+		amazonPage: 'amazon.com',
+	}, input));
+}
+
+async function captureRefreshInitInput(account) {
+	let initInput;
+
+	account.state.code = 'READY';
+	account.initAlexa = async input => {
+		initInput = input;
+		return { ok: true };
+	};
+
+	await account.refreshAlexa();
+	return initInput;
+}
+
+function createProxyCookieData() {
+	return {
+		loginCookie: 'login-cookie',
+		localCookie: 'csrf=csrf-token; session=session-token',
+		refreshToken: 'refresh-token',
+		accessToken: 'access-token',
+		macDms: 'mac-dms',
+		amazonPage: 'amazon.com',
+		dataVersion: 2,
+		tokenDate: 1234567890,
+	};
+}
+
+async function testRefreshUsesCurrentProxyCookieData() {
+	const account = createAccount({
+		authMethod: 'proxy',
+	});
+	const currentCookieData = {
+		...createProxyCookieData(),
+	};
+
+	account.alexa.cookieData = currentCookieData;
+	const initInput = await captureRefreshInitInput(account);
+
+	assert.deepStrictEqual(initInput, currentCookieData);
+}
+
+async function testRefreshIgnoresCurrentCookieDataWithoutLoginCookie() {
+	const account = createAccount({
+		authMethod: 'proxy',
+	});
+	const currentCookieData = createProxyCookieData();
+	delete currentCookieData.loginCookie;
+
+	account.alexa.cookieData = currentCookieData;
+	const initInput = await captureRefreshInitInput(account);
+
+	assert.strictEqual(initInput, undefined);
+}
+
+async function testRefreshKeepsFileBasedProxyInputEmpty() {
+	const account = createAccount({
+		authMethod: 'proxy',
+		cookieFile: '/tmp/alexa-cookie.json',
+	});
+
+	account.alexa.cookieData = createProxyCookieData();
+	const initInput = await captureRefreshInitInput(account);
+
+	assert.strictEqual(initInput, undefined);
+}
+
+async function testRefreshKeepsCookieAuthInputEmpty() {
+	const account = createAccount({
+		authMethod: 'cookie',
+	});
+
+	account.alexa.cookieData = createProxyCookieData();
+	const initInput = await captureRefreshInitInput(account);
+
+	assert.strictEqual(initInput, undefined);
+}
+
+Promise.resolve()
+	.then(testRefreshUsesCurrentProxyCookieData)
+	.then(testRefreshIgnoresCurrentCookieDataWithoutLoginCookie)
+	.then(testRefreshKeepsFileBasedProxyInputEmpty)
+	.then(testRefreshKeepsCookieAuthInputEmpty)
+	.then(() => {
+		console.log('refresh-current-cookie-data tests passed');
+	})
+	.catch(error => {
+		console.error(error);
+		process.exitCode = 1;
+	});


### PR DESCRIPTION
### Problem

`refreshAlexa()` currently reinitializes the account through `initAlexa(undefined)`.
For proxy-auth accounts that do not use a configured cookie file, the current auth data can exist only on the running Alexa instance as `this.alexa.cookieData`. `initAlexa()` only reads proxy auth data from its `input` argument or from the configured cookie file. It then calls `resetAlexa()`, replacing the current Alexa instance.
That means a refresh can discard valid in-memory proxy auth data before reinitializing.

### Change

`refreshAlexa()` now passes the current in-memory proxy `cookieData` into `initAlexa(...)` when all of these are true:

- auth method is `proxy`
- no cookie file is configured
- `this.alexa.cookieData` is an object
- it contains `loginCookie`

File-backed proxy accounts still call `initAlexa(undefined)`, preserving the existing cookie-file path and its current priority.

### Related issue

Related to #256.

This does not close #256. It covers one narrow refresh path: proxy-auth accounts without a cookie file, where the account already has current in-memory `cookieData` and the refresh path would otherwise call `initAlexa(undefined)`.

### Test

Added `test/refresh-current-cookie-data.test.js`.

The test covers:

- proxy refresh passes current in-memory `cookieData`
- proxy refresh ignores data without `loginCookie`
- file-backed proxy refresh keeps the previous empty input path
- cookie-auth refresh keeps the previous empty input path