### PR TITLE
fix: use registration data for token refresh

### DIFF
--- a/lib/alexa-remote-ext.js
+++ b/lib/alexa-remote-ext.js
@@ -243,18 +243,26 @@ class AlexaRemoteExt extends AlexaRemote {
 	async refreshAlexaCookies() {
 		const primaryOptions = this.options || {};
 		const legacyOptions = this._options || {};
-		const existingCookieData = primaryOptions.cookie || legacyOptions.cookie || this.cookieData;
+		const getTokenRegistrationData = data => tools.isObject(data) && data.loginCookie && data.refreshToken
+			? data
+			: undefined;
+		const tokenRegistrationData = getTokenRegistrationData(primaryOptions.formerRegistrationData)
+			|| getTokenRegistrationData(legacyOptions.formerRegistrationData)
+			|| getTokenRegistrationData(primaryOptions.cookie)
+			|| getTokenRegistrationData(legacyOptions.cookie)
+			|| getTokenRegistrationData(this.cookieData);
 
 		// Prefer alexa-remote2's native refresh flow when we have saved proxy auth data.
-		if (existingCookieData && typeof existingCookieData === 'object' && existingCookieData.loginCookie) {
+		if (tokenRegistrationData) {
 			try {
+				legacyOptions.formerRegistrationData = tokenRegistrationData;
 				const refreshed = await new Promise((resolve, reject) => {
 					if (!this.alexaCookie)
 						this.alexaCookie = requireUncached('alexa-cookie2');
-					this.alexaCookie.refreshAlexaCookie(this._options, (err, result) => err ? reject(err) : resolve(result));
+					this.alexaCookie.refreshAlexaCookie(legacyOptions, (err, result) => err ? reject(err) : resolve(result));
 				});
 
-				const refreshedCookieData = refreshed || this.cookieData || existingCookieData;
+				const refreshedCookieData = refreshed || this.cookieData || tokenRegistrationData;
 				primaryOptions.cookie = refreshedCookieData;
 				legacyOptions.cookie = refreshedCookieData;
 				this.setCookie(refreshedCookieData);

--- a/test/token-refresh-registration-data.test.js
+++ b/test/token-refresh-registration-data.test.js
@@ -1,0 +1,109 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const Module = require('module');
+
+class FakeAlexaRemote extends EventEmitter {
+	constructor() {
+		super();
+		this.cookie = null;
+		this.csrf = null;
+		this.cookieData = null;
+		this._options = {};
+	}
+
+	setCookie(cookie) {
+		if (cookie && cookie.localCookie) {
+			this.cookie = cookie.localCookie;
+			this.cookieData = cookie;
+			this._options.formerRegistrationData = cookie;
+		} else {
+			this.cookie = cookie;
+		}
+
+		const match = this.cookie && this.cookie.match(/csrf=([^;]+)/);
+		if (match) this.csrf = match[1];
+		this._options.cookie = this.cookie;
+		this._options.csrf = this.csrf;
+	}
+}
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+	if (request === 'alexa-remote2') return FakeAlexaRemote;
+	if (request === 'tough-cookie') return { CookieJar: class CookieJar {} };
+	return originalLoad.call(this, request, parent, isMain);
+};
+
+const AlexaRemoteExt = require('../lib/alexa-remote-ext.js');
+Module._load = originalLoad;
+
+function createCookieData(overrides) {
+	return Object.assign({
+		loginCookie: 'login-cookie',
+		localCookie: 'csrf=old-csrf; session=old-session',
+		refreshToken: 'refresh-token',
+		accessToken: 'old-access-token',
+		macDms: 'mac-dms',
+		deviceSerial: 'device-serial',
+		deviceAppName: 'device-app-name',
+		amazonPage: 'amazon.com',
+		dataVersion: 2,
+		tokenDate: Date.now() - 48 * 60 * 60 * 1000,
+	}, overrides);
+}
+
+async function testUsesFormerRegistrationDataWhenCookieOptionIsString() {
+	const alexa = new AlexaRemoteExt({ context: { global: {} } });
+	const formerRegistrationData = createCookieData();
+	const refreshedCookieData = createCookieData({
+		loginCookie: 'new-login-cookie',
+		localCookie: 'csrf=new-csrf; session=new-session',
+		accessToken: 'new-access-token',
+		tokenDate: Date.now(),
+	});
+	let refreshOptions;
+	let refreshFormerRegistrationData;
+
+	alexa.options = {};
+	alexa._options = {
+		cookie: formerRegistrationData.localCookie,
+		formerRegistrationData,
+		headers: {},
+		amazonPage: 'amazon.com',
+	};
+	alexa.cookieData = formerRegistrationData;
+	alexa.alexaCookie = {
+		refreshAlexaCookie: (options, callback) => {
+			refreshOptions = options;
+			refreshFormerRegistrationData = options.formerRegistrationData;
+			callback(null, refreshedCookieData);
+		},
+	};
+	alexa.auth = {
+		request: () => {
+			throw new Error('SPA fallback should not be used');
+		},
+	};
+
+	await alexa.refreshAlexaCookies();
+
+	assert.strictEqual(refreshFormerRegistrationData, formerRegistrationData);
+	assert.strictEqual(refreshOptions.formerRegistrationData, refreshedCookieData);
+	assert.strictEqual(alexa.cookieData, refreshedCookieData);
+	assert.strictEqual(alexa.cookie, refreshedCookieData.localCookie);
+	assert.strictEqual(alexa.csrf, 'new-csrf');
+	assert.strictEqual(alexa._options.formerRegistrationData, refreshedCookieData);
+	assert.strictEqual(alexa.options.cookie, refreshedCookieData);
+	assert.strictEqual(alexa._options.cookie, refreshedCookieData.localCookie);
+	assert.strictEqual(alexa.options.headers.Cookie, refreshedCookieData.localCookie);
+	assert.strictEqual(alexa._options.headers.Cookie, refreshedCookieData.localCookie);
+}
+
+testUsesFormerRegistrationDataWhenCookieOptionIsString()
+	.then(() => {
+		console.log('token-refresh-registration-data tests passed');
+	})
+	.catch(error => {
+		console.error(error);
+		process.exitCode = 1;
+	});


### PR DESCRIPTION
### Problem

`refreshAlexaCookies()` currently selects refresh input with `primaryOptions.cookie || legacyOptions.cookie || this.cookieData`.
After `alexa-remote2` has called `setCookie(...)`, `_options.cookie` can be the local cookie string, while the structured proxy auth data is stored in `_options.formerRegistrationData`.
When the string value is selected first, Applestrudel does not enter the token-refresh branch even though valid registration data with `loginCookie` and `refreshToken` is available. It then falls through to the SPA fallback.

### Change

The token-refresh path now selects structured registration data explicitly.
It accepts only objects that contain both `loginCookie` and `refreshToken`.

Selection order:

- `options.formerRegistrationData`
- `_options.formerRegistrationData`
- object-shaped `options.cookie`
- object-shaped `_options.cookie`
- `this.cookieData`

Before calling `alexa-cookie2.refreshAlexaCookie(...)`, the selected object is assigned on the options object passed to `refreshAlexaCookie(...)`.

The SPA fallback itself is unchanged.

### Related issue

Related to #256.
This does not fully close #256. It fixes one concrete refresh-path issue: token refresh should still be attempted when structured proxy registration data exists, even if `_options.cookie` currently contains only the local cookie string.

### Test

Added `test/token-refresh-registration-data.test.js`.
The test covers the case where `_options.cookie` is a local cookie string and `_options.formerRegistrationData` contains valid proxy registration data. It verifies that token refresh is used, the SPA fallback is not reached, and refreshed cookie data is written back to runtime state and request headers.
