### PR TITLE
fix: keep cookies across auth redirects

### DIFF
--- a/lib/auth/auth-controller.js
+++ b/lib/auth/auth-controller.js
@@ -3,6 +3,23 @@
 const http = require('http');
 const https = require('https');
 
+function mergeCookieHeader(existingHeader, setCookieHeaders) {
+	const cookieMap = new Map();
+	const addCookie = cookie => {
+		const separator = cookie.indexOf('=');
+		if (separator <= 0) return;
+		cookieMap.set(cookie.slice(0, separator).trim(), cookie.trim());
+	};
+
+	String(existingHeader || '').split(';').map(cookie => cookie.trim()).filter(Boolean).forEach(addCookie);
+	[]
+		.concat(setCookieHeaders || [])
+		.map(cookie => String(cookie || '').split(';')[0].trim())
+		.filter(Boolean)
+		.forEach(addCookie);
+	return Array.from(cookieMap.values()).join('; ');
+}
+
 class AlexaAuthController {
 	constructor(tokenStore, oauthDevice) {
 		this.tokenStore = tokenStore;
@@ -58,13 +75,8 @@ class AlexaAuthController {
 							&& res.headers.location) {
 						const redirectUrl = new URL(res.headers.location, requestUrl).toString();
 						const redirectHeaders = Object.assign({}, options.headers);
-						const cookieHeader = nextSetCookie
-							.map(cookie => String(cookie).split(';')[0])
-							.filter(Boolean)
-							.join('; ');
-						if (cookieHeader) redirectHeaders.Cookie = redirectHeaders.Cookie
-							? `${redirectHeaders.Cookie}; ${cookieHeader}`
-							: cookieHeader;
+						const cookieHeader = mergeCookieHeader(redirectHeaders.Cookie, nextSetCookie);
+						if (cookieHeader) redirectHeaders.Cookie = cookieHeader;
 						this.requestWithNodeHttp(redirectUrl, Object.assign({}, options, {
 							headers: redirectHeaders,
 							maxRedirects: options.maxRedirects - 1,

--- a/lib/auth/auth-controller.js
+++ b/lib/auth/auth-controller.js
@@ -20,6 +20,17 @@ function mergeCookieHeader(existingHeader, setCookieHeaders) {
 	return Array.from(cookieMap.values()).join('; ');
 }
 
+function getHeader(headers, name) {
+	const key = Object.keys(headers || {}).find(header => header.toLowerCase() === name.toLowerCase());
+	return key ? headers[key] : undefined;
+}
+
+function deleteHeader(headers, name) {
+	Object.keys(headers || {})
+		.filter(header => header.toLowerCase() === name.toLowerCase())
+		.forEach(header => delete headers[header]);
+}
+
 class AlexaAuthController {
 	constructor(tokenStore, oauthDevice) {
 		this.tokenStore = tokenStore;
@@ -75,7 +86,8 @@ class AlexaAuthController {
 							&& res.headers.location) {
 						const redirectUrl = new URL(res.headers.location, requestUrl).toString();
 						const redirectHeaders = Object.assign({}, options.headers);
-						const cookieHeader = mergeCookieHeader(redirectHeaders.Cookie, nextSetCookie);
+						const cookieHeader = mergeCookieHeader(getHeader(redirectHeaders, 'Cookie'), nextSetCookie);
+						deleteHeader(redirectHeaders, 'Cookie');
 						if (cookieHeader) redirectHeaders.Cookie = cookieHeader;
 						this.requestWithNodeHttp(redirectUrl, Object.assign({}, options, {
 							headers: redirectHeaders,

--- a/lib/auth/auth-controller.js
+++ b/lib/auth/auth-controller.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const http = require('http');
+const https = require('https');
+
 class AlexaAuthController {
 	constructor(tokenStore, oauthDevice) {
 		this.tokenStore = tokenStore;
@@ -7,7 +10,7 @@ class AlexaAuthController {
 	}
 
 	async ensureAuth() {
-		// OAuth2 bootstrap is handled by alexa-remote2 init flow.
+		// OAuth2 setup is handled by alexa-remote2 init flow.
 		// We only need to ensure this class is available for runtime wiring.
 		return true;
 	}
@@ -15,23 +18,57 @@ class AlexaAuthController {
 	async request(options = {}) {
 		const method = options.method || 'GET';
 		const headers = options.headers || {};
+		const maxRedirects = options.maxRedirects === undefined ? 5 : options.maxRedirects;
 
-		const response = await fetch(options.url, {
-			method: method,
-			headers: headers,
-			redirect: options.followRedirect ? 'follow' : 'manual',
+		const response = await this.requestWithNodeHttp(options.url, {
+			method,
+			headers,
+			followRedirect: !!options.followRedirect,
+			maxRedirects,
 		});
 
-		const setCookie = typeof response.headers.getSetCookie === 'function'
-			? response.headers.getSetCookie()
-			: [];
-
 		return {
-			statusCode: response.status,
+			statusCode: response.statusCode,
 			headers: {
-				'set-cookie': setCookie,
+				'set-cookie': response.headers['set-cookie'] || [],
 			},
 		};
+	}
+
+	requestWithNodeHttp(url, options) {
+		return new Promise((resolve, reject) => {
+			const requestUrl = new URL(url);
+			const client = requestUrl.protocol === 'https:' ? https : http;
+			const req = client.request(requestUrl, {
+				method: options.method,
+				headers: options.headers,
+			}, res => {
+				const chunks = [];
+				res.on('data', chunk => chunks.push(chunk));
+				res.on('end', () => {
+					if (options.followRedirect
+							&& options.maxRedirects > 0
+							&& res.statusCode >= 300
+							&& res.statusCode < 400
+							&& res.headers.location) {
+						const redirectUrl = new URL(res.headers.location, requestUrl).toString();
+						this.requestWithNodeHttp(redirectUrl, Object.assign({}, options, {
+							maxRedirects: options.maxRedirects - 1,
+						})).then(resolve, reject);
+						return;
+					}
+
+					resolve({
+						statusCode: res.statusCode,
+						headers: res.headers,
+						body: Buffer.concat(chunks).toString('utf8'),
+					});
+				});
+			});
+
+			req.on('error', reject);
+			req.end();
+		});
 	}
 }
 

--- a/lib/auth/auth-controller.js
+++ b/lib/auth/auth-controller.js
@@ -30,12 +30,12 @@ class AlexaAuthController {
 		return {
 			statusCode: response.statusCode,
 			headers: {
-				'set-cookie': response.headers['set-cookie'] || [],
+				'set-cookie': response.setCookie || [],
 			},
 		};
 	}
 
-	requestWithNodeHttp(url, options) {
+	requestWithNodeHttp(url, options, collectedSetCookie = []) {
 		return new Promise((resolve, reject) => {
 			const requestUrl = new URL(url);
 			const client = requestUrl.protocol === 'https:' ? https : http;
@@ -46,21 +46,36 @@ class AlexaAuthController {
 				const chunks = [];
 				res.on('data', chunk => chunks.push(chunk));
 				res.on('end', () => {
+					const responseSetCookie = []
+						.concat(res.headers['set-cookie'] || [])
+						.filter(Boolean);
+					const nextSetCookie = collectedSetCookie.concat(responseSetCookie);
+
 					if (options.followRedirect
 							&& options.maxRedirects > 0
 							&& res.statusCode >= 300
 							&& res.statusCode < 400
 							&& res.headers.location) {
 						const redirectUrl = new URL(res.headers.location, requestUrl).toString();
+						const redirectHeaders = Object.assign({}, options.headers);
+						const cookieHeader = nextSetCookie
+							.map(cookie => String(cookie).split(';')[0])
+							.filter(Boolean)
+							.join('; ');
+						if (cookieHeader) redirectHeaders.Cookie = redirectHeaders.Cookie
+							? `${redirectHeaders.Cookie}; ${cookieHeader}`
+							: cookieHeader;
 						this.requestWithNodeHttp(redirectUrl, Object.assign({}, options, {
+							headers: redirectHeaders,
 							maxRedirects: options.maxRedirects - 1,
-						})).then(resolve, reject);
+						}), nextSetCookie).then(resolve, reject);
 						return;
 					}
 
 					resolve({
 						statusCode: res.statusCode,
 						headers: res.headers,
+						setCookie: nextSetCookie,
 						body: Buffer.concat(chunks).toString('utf8'),
 					});
 				});

--- a/test/auth-controller-request.test.js
+++ b/test/auth-controller-request.test.js
@@ -73,6 +73,7 @@ async function testRequestKeepsCookiesAcrossRedirects() {
 			url: `${baseUrl}/redirect`,
 			headers: {
 				'User-Agent': 'test-agent',
+				Cookie: 'csrf=old-csrf; ubid-main=old-ubid',
 			},
 			followRedirect: true,
 		});
@@ -82,7 +83,7 @@ async function testRequestKeepsCookiesAcrossRedirects() {
 			'csrf=redirect-csrf; Path=/; Secure',
 			'session-id=final-session; Path=/; Secure',
 		]);
-		assert.strictEqual(seenCookieHeaders[0], 'csrf=redirect-csrf');
+		assert.strictEqual(seenCookieHeaders[0], 'csrf=redirect-csrf; ubid-main=old-ubid');
 	});
 }
 

--- a/test/auth-controller-request.test.js
+++ b/test/auth-controller-request.test.js
@@ -50,7 +50,45 @@ async function testRequestWorksWithoutGlobalFetch() {
 	}
 }
 
-testRequestWorksWithoutGlobalFetch()
+async function testRequestKeepsCookiesAcrossRedirects() {
+	const seenCookieHeaders = [];
+
+	await withServer((req, res) => {
+		if (req.url === '/redirect') {
+			res.statusCode = 302;
+			res.setHeader('Location', '/final');
+			res.setHeader('Set-Cookie', 'csrf=redirect-csrf; Path=/; Secure');
+			res.end();
+			return;
+		}
+
+		assert.strictEqual(req.url, '/final');
+		seenCookieHeaders.push(req.headers.cookie || '');
+		res.setHeader('Set-Cookie', 'session-id=final-session; Path=/; Secure');
+		res.end('ok');
+	}, async baseUrl => {
+		const controller = new AlexaAuthController({}, {});
+		const response = await controller.request({
+			method: 'GET',
+			url: `${baseUrl}/redirect`,
+			headers: {
+				'User-Agent': 'test-agent',
+			},
+			followRedirect: true,
+		});
+
+		assert.strictEqual(response.statusCode, 200);
+		assert.deepStrictEqual(response.headers['set-cookie'], [
+			'csrf=redirect-csrf; Path=/; Secure',
+			'session-id=final-session; Path=/; Secure',
+		]);
+		assert.strictEqual(seenCookieHeaders[0], 'csrf=redirect-csrf');
+	});
+}
+
+Promise.resolve()
+	.then(testRequestWorksWithoutGlobalFetch)
+	.then(testRequestKeepsCookiesAcrossRedirects)
 	.then(() => console.log('auth-controller-request tests passed'))
 	.catch(error => {
 		console.error(error);

--- a/test/auth-controller-request.test.js
+++ b/test/auth-controller-request.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const http = require('http');
+
+const { AlexaAuthController } = require('../lib/auth/auth-controller');
+
+async function withServer(handler, test) {
+	const server = http.createServer(handler);
+	await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+	try {
+		const { port } = server.address();
+		await test(`http://127.0.0.1:${port}`);
+	}
+	finally {
+		await new Promise(resolve => server.close(resolve));
+	}
+}
+
+async function testRequestWorksWithoutGlobalFetch() {
+	const previousFetch = global.fetch;
+	global.fetch = undefined;
+
+	try {
+		await withServer((req, res) => {
+			assert.strictEqual(req.method, 'GET');
+			assert.strictEqual(req.headers['user-agent'], 'test-agent');
+			res.setHeader('Set-Cookie', [
+				'csrf=test-csrf; Path=/; Secure',
+				'session-id=test-session; Path=/; Secure',
+			]);
+			res.end('ok');
+		}, async baseUrl => {
+			const controller = new AlexaAuthController({}, {});
+			const response = await controller.request({
+				method: 'GET',
+				url: `${baseUrl}/spa/index.html`,
+				headers: {
+					'User-Agent': 'test-agent',
+				},
+			});
+
+			assert.strictEqual(response.statusCode, 200);
+			assert.deepStrictEqual(response.headers['set-cookie'], [
+				'csrf=test-csrf; Path=/; Secure',
+				'session-id=test-session; Path=/; Secure',
+			]);
+		});
+	}
+	finally {
+		global.fetch = previousFetch;
+	}
+}
+
+testRequestWorksWithoutGlobalFetch()
+	.then(() => console.log('auth-controller-request tests passed'))
+	.catch(error => {
+		console.error(error);
+		process.exitCode = 1;
+	});

--- a/test/auth-controller-request.test.js
+++ b/test/auth-controller-request.test.js
@@ -87,9 +87,41 @@ async function testRequestKeepsCookiesAcrossRedirects() {
 	});
 }
 
+async function testRequestKeepsLowercaseCookieHeaderAcrossRedirects() {
+	const seenCookieHeaders = [];
+
+	await withServer((req, res) => {
+		if (req.url === '/redirect') {
+			res.statusCode = 302;
+			res.setHeader('Location', '/final');
+			res.setHeader('Set-Cookie', 'csrf=redirect-csrf; Path=/; Secure');
+			res.end();
+			return;
+		}
+
+		assert.strictEqual(req.url, '/final');
+		seenCookieHeaders.push(req.headers.cookie || '');
+		res.end('ok');
+	}, async baseUrl => {
+		const controller = new AlexaAuthController({}, {});
+		await controller.request({
+			method: 'GET',
+			url: `${baseUrl}/redirect`,
+			headers: {
+				'User-Agent': 'test-agent',
+				cookie: 'csrf=old-csrf; ubid-main=old-ubid',
+			},
+			followRedirect: true,
+		});
+
+		assert.strictEqual(seenCookieHeaders[0], 'csrf=redirect-csrf; ubid-main=old-ubid');
+	});
+}
+
 Promise.resolve()
 	.then(testRequestWorksWithoutGlobalFetch)
 	.then(testRequestKeepsCookiesAcrossRedirects)
+	.then(testRequestKeepsLowercaseCookieHeaderAcrossRedirects)
 	.then(() => console.log('auth-controller-request tests passed'))
 	.catch(error => {
 		console.error(error);


### PR DESCRIPTION
### Problem

The auth controller request helper used `fetch()`. That makes the behavior depend on the runtime-provided fetch implementation and does not explicitly preserve cookies across manually followed redirects.

During auth-related requests, redirect responses can set cookies that must be sent to the next redirected request. If those cookies are not merged into the next request, later auth steps can see stale or incomplete cookie state.

### Change

This replaces the `fetch()` based request helper with Node's built-in `http`/`https` modules.

The request helper now:

- works without a global `fetch`
- follows redirects when requested
- collects `set-cookie` headers across redirect responses
- merges redirect cookies into the next request cookie header
- handles `Cookie` header casing consistently

### Tests

Added `test/auth-controller-request.test.js`.

It covers:

- request behavior without global `fetch`
- preserving cookies across redirects
- lower-case `cookie` request headers during redirects

### Scope

This only changes the auth controller request helper. It does not change the higher-level account initialization or refresh decision logic.