### PR TITLE
fix: redact cookie data in account debug output

### DIFF
--- a/nodes/alexa-remote-account.js
+++ b/nodes/alexa-remote-account.js
@@ -483,7 +483,10 @@ module.exports = function (RED) {
 			this.logCb(`intialising ${this.name ? `"${this.name}" ` : ''}with the ${initType.toUpperCase()} method and ${config.cookie ? '' : 'NO '}saved data...`);
 
 			this.debugCb(`Alexa-Remote: starting initialisation:`);
-			this.debugCb(`Alexa-Remote: ${JSON.stringify({authMethod: this.authMethod, initType: initType, cookie: config.cookie})}`);
+			const debugCookie = config.cookie
+				? { present: true, type: Array.isArray(config.cookie) ? 'array' : typeof config.cookie }
+				: { present: false };
+			this.debugCb(`Alexa-Remote: ${JSON.stringify({ authMethod: this.authMethod, initType: initType, cookie: debugCookie })}`);
 
 			// the this.alexa we init could change once the this.alexa.initExt is complete because
 			// this.resetAlexa() or this.initAlexa() might have been called again during this time

--- a/test/account-debug-cookie-redaction.test.js
+++ b/test/account-debug-cookie-redaction.test.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const alexaRemotePath = path.join(repoRoot, 'lib', 'alexa-remote-ext.js');
+const accountNodePath = path.join(repoRoot, 'nodes', 'alexa-remote-account.js');
+
+class FakeAlexaRemote extends EventEmitter {
+	constructor() {
+		super();
+		this.cookieData = undefined;
+		this.errorMessagesExt = {};
+	}
+
+	setMaxListeners(value) {
+		super.setMaxListeners(value);
+		return this;
+	}
+
+	resetExt() {}
+
+	async initExt(config) {
+		this.cookieData = config.cookie || null;
+		return this.cookieData;
+	}
+}
+
+function loadAccountNode() {
+	delete require.cache[accountNodePath];
+	require.cache[alexaRemotePath] = {
+		id: alexaRemotePath,
+		filename: alexaRemotePath,
+		loaded: true,
+		exports: FakeAlexaRemote,
+	};
+
+	let AccountNode;
+	const RED = {
+		nodes: {
+			createNode(node, input = {}) {
+				const emitter = new EventEmitter();
+				node.on = emitter.on.bind(emitter);
+				node.emit = emitter.emit.bind(emitter);
+				node.status = () => {};
+				node.log = () => {};
+				node.warn = () => {};
+				node.error = () => {};
+				node.debug = value => {
+					if (input.__debugLog) input.__debugLog.push(String(value));
+				};
+				node.context = () => ({});
+				node.credentials = {};
+			},
+			registerType(name, constructor) {
+				if (name === 'alexa-remote-account') AccountNode = constructor;
+			},
+		},
+		auth: {
+			needsPermission: () => () => {},
+		},
+		httpAdmin: {
+			get: () => {},
+		},
+	};
+
+	require(accountNodePath)(RED);
+	assert(AccountNode, 'Account node was not registered');
+	return AccountNode;
+}
+
+function createAccount(input) {
+	const AccountNode = loadAccountNode();
+	return new AccountNode(Object.assign({
+		authMethod: 'proxy',
+		refreshInterval: '',
+		amazonPage: 'amazon.com',
+	}, input));
+}
+
+async function testInitAlexaDoesNotDebugRawCookieData() {
+	const debugLog = [];
+	const account = createAccount({ __debugLog: debugLog });
+	const cookieData = {
+		loginCookie: 'login-cookie-secret',
+		localCookie: 'csrf=secret-csrf; session-id=secret-session',
+		refreshToken: 'secret-refresh',
+		accessToken: 'secret-access',
+		amazonPage: 'amazon.com',
+		dataVersion: 2,
+	};
+
+	account.buildUiJson = async () => {};
+	account.renewTimeout = () => {};
+
+	await account.initAlexa(cookieData);
+
+	const joined = debugLog.join('\n');
+	assert(!joined.includes('login-cookie-secret'), 'loginCookie leaked through Node-RED debug output');
+	assert(!joined.includes('secret-csrf'), 'csrf leaked through Node-RED debug output');
+	assert(!joined.includes('secret-session'), 'session leaked through Node-RED debug output');
+	assert(!joined.includes('secret-refresh'), 'refresh token leaked through Node-RED debug output');
+	assert(!joined.includes('secret-access'), 'access token leaked through Node-RED debug output');
+}
+
+testInitAlexaDoesNotDebugRawCookieData()
+	.then(() => console.log('account-debug-cookie-redaction tests passed'))
+	.catch(error => {
+		console.error(error);
+		process.exitCode = 1;
+	});


### PR DESCRIPTION
### Problem

The account node debug output logged the configured `cookie` value during initialization.
For proxy auth, that value can be structured auth data and may contain sensitive cookie or token fields. Debug output should confirm whether cookie input exists without printing the raw value.

### Change

The debug output now logs only cookie presence and value type.
It no longer serializes the raw cookie/auth data into Node-RED debug output.

### Tests

Added `test/account-debug-cookie-redaction.test.js`.
The test verifies that debug output does not contain raw cookie, CSRF, session, refresh token, or access token values.

### Scope

This only changes debug logging. It does not change auth behavior, stored data, refresh behavior, or proxy login flow.